### PR TITLE
Fixed calls to logp.Info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 filebeat
 .DS_Store
 .filebeat
+*.swp
+*.swo
 
 cover
 profile.cov

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ run: build
 .PHONY: test
 test:
 	$(GODEP) go test -short ./...
-	make -C tests test
 
 .PHONY: cover
 cover:

--- a/beat/filebeat.go
+++ b/beat/filebeat.go
@@ -3,15 +3,16 @@ package beat
 import (
 	"flag"
 	"fmt"
+	"os"
+	"time"
+
 	cfg "github.com/elastic/filebeat/config"
 	. "github.com/elastic/filebeat/crawler"
 	. "github.com/elastic/filebeat/input"
 	"github.com/elastic/libbeat/beat"
+	"github.com/elastic/libbeat/cfgfile"
 	"github.com/elastic/libbeat/common"
 	"github.com/elastic/libbeat/logp"
-	"os"
-	"time"
-	"github.com/elastic/libbeat/cfgfile"
 )
 
 var exitStat = struct {
@@ -111,14 +112,14 @@ func (fb *Filebeat) Stop() {
 
 // emitOptions prints out the set config options
 func emitOptions() {
-	logp.Info("filebeat", "\t--- options -------")
-	logp.Info("filebeat", "\tconfig-arg:          %s", configDirPath)
-	logp.Info("filebeat", "\tidle-timeout:        %v", cfg.CmdlineOptions.IdleTimeout)
-	logp.Info("filebeat", "\tspool-size:          %d", cfg.CmdlineOptions.SpoolSize)
-	logp.Info("filebeat", "\tharvester-buff-size: %d", cfg.CmdlineOptions.HarvesterBufferSize)
-	logp.Info("filebeat", "\t--- flags ---------")
-	logp.Info("filebeat", "\ttail (on-rotation):  %t", cfg.CmdlineOptions.TailOnRotate)
-	logp.Info("filebeat", "\tquiet:             %t", cfg.CmdlineOptions.Quiet)
+	logp.Info("\t--- options -------")
+	logp.Info("\tconfig-arg:          %s", configDirPath)
+	logp.Info("\tidle-timeout:        %v", cfg.CmdlineOptions.IdleTimeout)
+	logp.Info("\tspool-size:          %d", cfg.CmdlineOptions.SpoolSize)
+	logp.Info("\tharvester-buff-size: %d", cfg.CmdlineOptions.HarvesterBufferSize)
+	logp.Info("\t--- flags ---------")
+	logp.Info("\ttail (on-rotation):  %t", cfg.CmdlineOptions.TailOnRotate)
+	logp.Info("\tquiet:             %t", cfg.CmdlineOptions.Quiet)
 }
 
 func Publish(beat *beat.Beat, fb *Filebeat) {

--- a/beat/registrar.go
+++ b/beat/registrar.go
@@ -2,15 +2,16 @@ package beat
 
 import (
 	"encoding/json"
+	"os"
+
 	. "github.com/elastic/filebeat/input"
 	"github.com/elastic/libbeat/logp"
-	"os"
 )
 
 func Registrar(state map[string]*FileState, input chan []*FileEvent) {
-	logp.Info("registrar", "Starting Registrar")
+	logp.Debug("registrar", "Starting Registrar")
 	for events := range input {
-		logp.Info("registrar", "Registrar: processing %d events", len(events))
+		logp.Debug("registrar", "Registrar: processing %d events", len(events))
 		// Take the last event found for each file source
 		for _, event := range events {
 			// skip stdin
@@ -23,10 +24,10 @@ func Registrar(state map[string]*FileState, input chan []*FileEvent) {
 
 		if e := writeRegistry(state, ".filebeat"); e != nil {
 			// REVU: but we should panic, or something, right?
-			logp.Info("registrar", "WARNING: (continuing) update of registry returned error: %s", e)
+			logp.Warn("WARNING: (continuing) update of registry returned error: %s", e)
 		}
 	}
-	logp.Info("registrar", "Ending Registrar")
+	logp.Debug("registrar", "Ending Registrar")
 }
 
 // writeRegistry Writes the new json registry file  to disk
@@ -34,7 +35,7 @@ func writeRegistry(state map[string]*FileState, path string) error {
 	tempfile := path + ".new"
 	file, e := os.Create(tempfile)
 	if e != nil {
-		logp.Info("registrar", "Failed to create tempfile (%s) for writing: %s", tempfile, e)
+		logp.Err("Failed to create tempfile (%s) for writing: %s", tempfile, e)
 		return e
 	}
 	defer file.Close()

--- a/input/file.go
+++ b/input/file.go
@@ -1,8 +1,9 @@
 package input
 
 import (
-	"github.com/elastic/libbeat/logp"
 	"os"
+
+	"github.com/elastic/libbeat/logp"
 )
 
 type FileEvent struct {
@@ -49,18 +50,18 @@ func (f *FileEvent) GetState() *FileState {
 // Check that the file isn't a symlink, mode is regular or file is nil
 func (f *File) IsRegularFile() bool {
 	if f.File == nil {
-		logp.Info("Harvester: BUG: f arg is nil")
+		logp.Critical("Harvester: BUG: f arg is nil")
 		return false
 	}
 
 	info, e := f.File.Stat()
 	if e != nil {
-		logp.Info("File check fault: stat error: %s", e.Error())
+		logp.Err("File check fault: stat error: %s", e.Error())
 		return false
 	}
 
 	if !info.Mode().IsRegular() {
-		logp.Info("Harvester: not a regular file: %q %s", info.Mode(), info.Name())
+		logp.Warn("Harvester: not a regular file: %q %s", info.Mode(), info.Name())
 		return false
 	}
 	return true

--- a/input/filecompare.go
+++ b/input/filecompare.go
@@ -3,9 +3,10 @@
 package input
 
 import (
-	"github.com/elastic/libbeat/logp"
 	"os"
 	"syscall"
+
+	"github.com/elastic/libbeat/logp"
 )
 
 func IsSameFile(path string, info os.FileInfo, state *FileState) bool {


### PR DESCRIPTION
In many places logp.Info was called with a module name, but only
logp.Debug accepts that. In some places I changed logp.Info with other
error level (err, warn or debug), in some places I just removed the
parameter.