### PR TITLE
Fix compile error on Windows.

### DIFF
--- a/crawler/prospector_windows.go
+++ b/crawler/prospector_windows.go
@@ -1,5 +1,11 @@
 package crawler
 
+import (
+	"os"
+
+	"github.com/elastic/filebeat/input"
+)
+
 // TODO: Implement
 func (p *Prospector) isFileRenamed(file string, info os.FileInfo, missingfiles map[string]os.FileInfo) string {
 	// Can we detect if a file was renamed on Windows?
@@ -7,7 +13,7 @@ func (p *Prospector) isFileRenamed(file string, info os.FileInfo, missingfiles m
 	return ""
 }
 
-func (p *Prospector) isFileRenamedResumelist(file string, info os.FileInfo, initial map[string]*FileState) string {
+func (p *Prospector) isFileRenamedResumelist(file string, info os.FileInfo, initial map[string]*input.FileState) string {
 	// Can we detect if a file was renamed on Windows?
 	// NOTE(driskell): What about using golang's func os.SameFile(fi1, fi2 FileInfo) bool?
 	return ""


### PR DESCRIPTION
This just fixes the compile errors. There are other issues I noticed, but with this change it starts and is able to send a simple log file.