### PR TITLE
Removed references to Packetbeat in the configuration file

### DIFF
--- a/etc/filebeat.dev.yml
+++ b/etc/filebeat.dev.yml
@@ -52,6 +52,9 @@ shipper:
  # to remove duplicates if shippers are installed on multiple servers.
  # ignore_outgoing: true
 
+
+
+
 ############################# Output ############################################
 
 # Configure what outputs to use when sending the data collected by filebeat.
@@ -61,17 +64,20 @@ output:
   # Elasticsearch as output
   # Options:
   # host, port: where Elasticsearch is listening on
+  # save_topology: specify if the topology is saved in Elasticsearch
   elasticsearch:
     enabled: true
-    hosts: ["localhost:9200"]
+    hosts: ["192.168.99.100:9200"]
 
   # Redis as output
   # Options:
   # host, port: where Redis is listening on
+  # save_topology: specify if the topology is saved in Redis
   #redis:
   #  enabled: true
   #  host: localhost
   #  port: 6379
+  #  save_topology: true
 
   # File as output
   # Options:


### PR DESCRIPTION
Also, made the default elasticsearch output use "localhost" (this
is the file that we put in packages). I added a filebeat.dev.yml which
we can freely change for the dev environment. This is similar to
what topbeat and packetbeat have.