### PR TITLE
Config refactoring

### DIFF
--- a/beat/filebeat.go
+++ b/beat/filebeat.go
@@ -98,8 +98,14 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	registrar.LoadState(crawler.Files)
 	crawler.Start(fb.FbConfig.Filebeat.Files, persist, fb.SpoolChan)
 
-	// Start spooler: Harvesters dump events into the spooler.
+	// Init and Start spooler: Harvesters dump events into the spooler.
 	spooler := NewSpooler(fb)
+	err := spooler.Init()
+
+	if (err != nil) {
+		fmt.Print("Could not init spooler: %s", err)
+	}
+
 	fb.Spooler = spooler
 
 	go spooler.Start()
@@ -136,7 +142,6 @@ func (fb *Filebeat) Stop() {
 func emitOptions() {
 	logp.Info("\t--- options -------")
 	logp.Info("\tconfig-arg:          %s", configDirPath)
-	logp.Info("\tidle-timeout:        %v", cfg.CmdlineOptions.IdleTimeout)
 	logp.Info("\tharvester-buff-size: %d", cfg.CmdlineOptions.HarvesterBufferSize)
 	logp.Info("\t--- flags ---------")
 	logp.Info("\ttail (on-rotation):  %t", cfg.CmdlineOptions.TailOnRotate)

--- a/beat/filebeat.go
+++ b/beat/filebeat.go
@@ -103,7 +103,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	err := spooler.Init()
 
 	if err != nil {
-		fmt.Print("Could not init spooler: %s", err)
+		logp.Err("Could not init spooler: %v", err)
 	}
 
 	fb.Spooler = spooler

--- a/beat/filebeat.go
+++ b/beat/filebeat.go
@@ -102,7 +102,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	spooler := NewSpooler(fb)
 	err := spooler.Init()
 
-	if (err != nil) {
+	if err != nil {
 		fmt.Print("Could not init spooler: %s", err)
 	}
 

--- a/beat/filebeat.go
+++ b/beat/filebeat.go
@@ -142,7 +142,6 @@ func (fb *Filebeat) Stop() {
 func emitOptions() {
 	logp.Info("\t--- options -------")
 	logp.Info("\tconfig-arg:          %s", configDirPath)
-	logp.Info("\tharvester-buff-size: %d", cfg.CmdlineOptions.HarvesterBufferSize)
 	logp.Info("\t--- flags ---------")
 	logp.Info("\ttail (on-rotation):  %t", cfg.CmdlineOptions.TailOnRotate)
 	logp.Info("\tquiet:             %t", cfg.CmdlineOptions.Quiet)

--- a/beat/filebeat.go
+++ b/beat/filebeat.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/libbeat/logp"
 )
 
+// TODO: Cleanup if possible
 var exitStat = struct {
 	ok, usageError, faulted int
 }{
@@ -42,8 +43,6 @@ type Filebeat struct {
 
 // Config setups up the filebeat configuration by fetch all additional config files
 func (fb *Filebeat) Config(b *beat.Beat) error {
-
-	emitOptions()
 
 	// Load Base config
 	err := cfgfile.Read(&fb.FbConfig, "")
@@ -136,12 +135,6 @@ func (fb *Filebeat) Stop() {
 	close(fb.SpoolChan)
 	close(fb.publisherChan)
 	close(fb.RegistrarChan)
-}
-
-// emitOptions prints out the set config options
-func emitOptions() {
-	logp.Info("\t--- flags ---------")
-	logp.Info("\ttail (on-rotation):  %t", cfg.CmdlineOptions.TailOnRotate)
 }
 
 func Publish(beat *beat.Beat, fb *Filebeat) {

--- a/beat/filebeat.go
+++ b/beat/filebeat.go
@@ -140,11 +140,8 @@ func (fb *Filebeat) Stop() {
 
 // emitOptions prints out the set config options
 func emitOptions() {
-	logp.Info("\t--- options -------")
-	logp.Info("\tconfig-arg:          %s", configDirPath)
 	logp.Info("\t--- flags ---------")
 	logp.Info("\ttail (on-rotation):  %t", cfg.CmdlineOptions.TailOnRotate)
-	logp.Info("\tquiet:             %t", cfg.CmdlineOptions.Quiet)
 }
 
 func Publish(beat *beat.Beat, fb *Filebeat) {

--- a/beat/filebeat.go
+++ b/beat/filebeat.go
@@ -103,6 +103,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 
 	if err != nil {
 		logp.Err("Could not init spooler: %v", err)
+		return err
 	}
 
 	fb.Spooler = spooler

--- a/beat/spooler.go
+++ b/beat/spooler.go
@@ -3,8 +3,8 @@ package beat
 import (
 	cfg "github.com/elastic/filebeat/config"
 	"github.com/elastic/filebeat/input"
+	"github.com/elastic/libbeat/logp"
 	"time"
-"github.com/elastic/libbeat/logp"
 )
 
 type Spooler struct {
@@ -42,7 +42,6 @@ func (spooler *Spooler) Init() error {
 		// Set it to default
 		config.IdleTimeoutDuration = cfg.DefaultIdleTimeout
 	}
-
 
 	return nil
 }

--- a/beat/spooler.go
+++ b/beat/spooler.go
@@ -22,25 +22,25 @@ func NewSpooler(filebeat *Filebeat) *Spooler {
 func (spooler *Spooler) Init() error {
 	config := &spooler.Filebeat.FbConfig.Filebeat
 
-	// Set default pool size is set to 0
+	// Set default pool size if value not set
 	if config.SpoolSize == 0 {
 		config.SpoolSize = cfg.DefaultSpoolSize
 	}
 
-	if spooler.Filebeat.FbConfig.Filebeat.IdleTimeout != "" {
-
+	// Set default idle timeout if not set
+	if config.IdleTimeout == "" {
+		logp.Debug("spooler", "Set idleTimeoutDuration to %s", cfg.DefaultIdleTimeout)
+		// Set it to default
+		config.IdleTimeoutDuration = cfg.DefaultIdleTimeout
+	} else {
 		var err error
 
 		config.IdleTimeoutDuration, err = time.ParseDuration(config.IdleTimeout)
 
 		if err != nil {
-			logp.Warn("Failed to parse idle timeout duration '%s'. Error was: %s\n", config.IdleTimeout, err)
+			logp.Warn("Failed to parse idle timeout duration '%s'. Error was: %v", config.IdleTimeout, err)
 			return err
 		}
-	} else {
-		logp.Debug("spooler", "Set idleTimeoutDuration to %s", cfg.DefaultIdleTimeout)
-		// Set it to default
-		config.IdleTimeoutDuration = cfg.DefaultIdleTimeout
 	}
 
 	return nil

--- a/beat/spooler.go
+++ b/beat/spooler.go
@@ -1,33 +1,50 @@
 package beat
 
 import (
-	cfg "github.com/elastic/filebeat/config"
 	"github.com/elastic/filebeat/input"
+	cfg "github.com/elastic/filebeat/config"
 	"time"
 )
 
-var stopSpooler = false
+type Spooler struct {
+	Filebeat *Filebeat
+	running  bool
+}
 
-// startSpooler Starts up the spooler and starts listening on the spool channel from the harvester
-// Sends then bulk updates to the publisher channel
-func (fb *Filebeat) startSpooler(options *cfg.FilebeatConfig) {
+func NewSpooler(filebeat *Filebeat) *Spooler {
+	spooler := &Spooler{
+		Filebeat: filebeat,
+		running:  true,
+	}
+
+	// Set default pool size is set to 0
+	if (spooler.Filebeat.FbConfig.Filebeat.SpoolSize == 0) {
+		spooler.Filebeat.FbConfig.Filebeat.SpoolSize = cfg.DefaultSpoolSize
+	}
+
+	return spooler
+}
+
+func (s *Spooler) Start() {
 	// heartbeat periodically. If the last flush was longer than
 	// 'idle_timeout' time ago, then we'll force a flush to prevent us from
 	// holding on to spooled events for too long.
 
-	ticker := time.NewTicker(options.IdleTimeout / 2)
+	config := &s.Filebeat.FbConfig.Filebeat
+
+	ticker := time.NewTicker(config.IdleTimeout / 2)
 
 	// slice for spooling into
 	// TODO(sissel): use container.Ring?
-	spool := make([]*input.FileEvent, options.SpoolSize)
+	spool := make([]*input.FileEvent, config.SpoolSize)
 
 	// Current write position in the spool
 	var spool_i int = 0
 
-	next_flush_time := time.Now().Add(options.IdleTimeout)
+	next_flush_time := time.Now().Add(config.IdleTimeout)
 	for {
 		select {
-		case event := <-fb.SpoolChan:
+		case event := <-s.Filebeat.SpoolChan:
 			spool[spool_i] = event
 			spool_i++
 
@@ -39,8 +56,8 @@ func (fb *Filebeat) startSpooler(options *cfg.FilebeatConfig) {
 				spoolcopy = append(spoolcopy, spool[:]...)
 
 				// Send events to publisher
-				fb.publisherChan <- spoolcopy
-				next_flush_time = time.Now().Add(options.IdleTimeout)
+				s.Filebeat.publisherChan <- spoolcopy
+				next_flush_time = time.Now().Add(config.IdleTimeout)
 
 				spool_i = 0
 			}
@@ -54,19 +71,19 @@ func (fb *Filebeat) startSpooler(options *cfg.FilebeatConfig) {
 				if spool_i > 0 {
 					var spoolcopy []*input.FileEvent
 					spoolcopy = append(spoolcopy, spool[0:spool_i]...)
-					fb.publisherChan <- spoolcopy
-					next_flush_time = now.Add(options.IdleTimeout)
+					s.Filebeat.publisherChan <- spoolcopy
+					next_flush_time = now.Add(config.IdleTimeout)
 					spool_i = 0
 				}
 			}
 		}
 
-		if stopSpooler {
+		if !s.running {
 			break
 		}
 	}
 }
 
-func (fb *Filebeat) stopSpooler() {
-	stopSpooler = true
+func (s *Spooler) Stop() {
+	s.running = false
 }

--- a/beat/spooler_test.go
+++ b/beat/spooler_test.go
@@ -3,8 +3,8 @@ package beat
 import (
 	cfg "github.com/elastic/filebeat/config"
 	"github.com/stretchr/testify/assert"
-	"testing"
 	"gopkg.in/yaml.v2"
+	"testing"
 )
 
 func TestNewSpoolerDefaultConfig(t *testing.T) {

--- a/beat/spooler_test.go
+++ b/beat/spooler_test.go
@@ -1,0 +1,34 @@
+package beat
+
+import (
+	"github.com/stretchr/testify/assert"
+	cfg "github.com/elastic/filebeat/config"
+	"testing"
+)
+
+
+func TestNewSpoolerDefaultConfig(t *testing.T) {
+
+	config := cfg.FilebeatConfig{}
+	fbConfig := &cfg.Config{Filebeat: config}
+
+	fb := &Filebeat{FbConfig:fbConfig}
+	NewSpooler(fb)
+
+
+	assert.Equal(t, cfg.DefaultSpoolSize, fb.FbConfig.Filebeat.SpoolSize)
+}
+
+func TestNewSpoolerSpoolSize(t *testing.T) {
+
+	spoolSize := uint64(19)
+	config := cfg.FilebeatConfig{SpoolSize: spoolSize}
+
+	fbConfig := &cfg.Config{Filebeat: config}
+
+	fb := &Filebeat{FbConfig:fbConfig}
+	NewSpooler(fb)
+
+
+	assert.Equal(t, spoolSize, fb.FbConfig.Filebeat.SpoolSize)
+}

--- a/beat/spooler_test.go
+++ b/beat/spooler_test.go
@@ -1,20 +1,19 @@
 package beat
 
 import (
-	"github.com/stretchr/testify/assert"
 	cfg "github.com/elastic/filebeat/config"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
-
 
 func TestNewSpoolerDefaultConfig(t *testing.T) {
 
 	config := cfg.FilebeatConfig{}
 	fbConfig := &cfg.Config{Filebeat: config}
 
-	fb := &Filebeat{FbConfig:fbConfig}
-	NewSpooler(fb)
-
+	fb := &Filebeat{FbConfig: fbConfig}
+	spooler := NewSpooler(fb)
+	spooler.Init()
 
 	assert.Equal(t, cfg.DefaultSpoolSize, fb.FbConfig.Filebeat.SpoolSize)
 }
@@ -26,9 +25,23 @@ func TestNewSpoolerSpoolSize(t *testing.T) {
 
 	fbConfig := &cfg.Config{Filebeat: config}
 
-	fb := &Filebeat{FbConfig:fbConfig}
-	NewSpooler(fb)
-
+	fb := &Filebeat{FbConfig: fbConfig}
+	spooler := NewSpooler(fb)
+	spooler.Init()
 
 	assert.Equal(t, spoolSize, fb.FbConfig.Filebeat.SpoolSize)
+}
+
+func TestNewSpoolerIdleTimeout(t *testing.T) {
+
+	idleTimoeout := "10s"
+	config := cfg.FilebeatConfig{IdleTimeout: idleTimoeout}
+
+	fbConfig := &cfg.Config{Filebeat: config}
+
+	fb := &Filebeat{FbConfig: fbConfig}
+	spooler := NewSpooler(fb)
+	spooler.Init()
+
+	assert.Equal(t, idleTimoeout, fb.FbConfig.Filebeat.IdleTimeout)
 }

--- a/beat/spooler_test.go
+++ b/beat/spooler_test.go
@@ -4,11 +4,14 @@ import (
 	cfg "github.com/elastic/filebeat/config"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"gopkg.in/yaml.v2"
 )
 
 func TestNewSpoolerDefaultConfig(t *testing.T) {
 
-	config := cfg.FilebeatConfig{}
+	var config cfg.FilebeatConfig
+	// Read from empty yaml config
+	yaml.Unmarshal([]byte(""), &config)
 	fbConfig := &cfg.Config{Filebeat: config}
 
 	fb := &Filebeat{FbConfig: fbConfig}
@@ -16,6 +19,7 @@ func TestNewSpoolerDefaultConfig(t *testing.T) {
 	spooler.Init()
 
 	assert.Equal(t, cfg.DefaultSpoolSize, fb.FbConfig.Filebeat.SpoolSize)
+	assert.Equal(t, cfg.DefaultIdleTimeout, fb.FbConfig.Filebeat.IdleTimeoutDuration)
 }
 
 func TestNewSpoolerSpoolSize(t *testing.T) {

--- a/changelog.md
+++ b/changelog.md
@@ -59,6 +59,7 @@ Notes:
 * All command line options must be available as config options for the beats
 * On debug we should print out all config options on startup -> any good idea how to do this recursively?
 * Quiet option remove as logging is part of libbeat
+* TailOnRate config option implemented and removed from command line
 
 Next with priority
 * Multi line support

--- a/changelog.md
+++ b/changelog.md
@@ -58,6 +58,7 @@ Notes:
 * We need general concept / code that command line args overwrite config options
 * All command line options must be available as config options for the beats
 * On debug we should print out all config options on startup -> any good idea how to do this recursively?
+* Quiet option remove as logging is part of libbeat
 
 Next with priority
 * Multi line support

--- a/changelog.md
+++ b/changelog.md
@@ -48,7 +48,8 @@ Questions:
 * What should we do about multiple configs? Just provide some docs? https://github.com/elastic/logstash-forwarder/issues/136 currently working with -c for beat -config for dirs
 * Command line config option -config was renamed to configDir. Should also be introduced as config file param in case we want to keep it
 * Rethink dead-time: https://github.com/elastic/logstash-forwarder/issues/460
-* spoolSize as cmd line option removed
+* spoolSize and idleTimeout as cmd line option removed
+* HarvesterBufferSize removed as cmd line option and moved it into the prospector config
 
 Notes:
 * Should every config entry have a name -> make it possible to know from which config entry something comes.
@@ -56,6 +57,7 @@ Notes:
 * All beats should "namespace" the config file, otherwise would could have overlaps. Means also for packetbeat, everything should be under "packetbeat"
 * We need general concept / code that command line args overwrite config options
 * All command line options must be available as config options for the beats
+* On debug we should print out all config options on startup -> any good idea how to do this recursively?
 
 Next with priority
 * Multi line support

--- a/changelog.md
+++ b/changelog.md
@@ -48,6 +48,7 @@ Questions:
 * What should we do about multiple configs? Just provide some docs? https://github.com/elastic/logstash-forwarder/issues/136 currently working with -c for beat -config for dirs
 * Command line config option -config was renamed to configDir. Should also be introduced as config file param in case we want to keep it
 * Rethink dead-time: https://github.com/elastic/logstash-forwarder/issues/460
+* spoolSize as cmd line option removed
 
 Notes:
 * Should every config entry have a name -> make it possible to know from which config entry something comes.

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"flag"
 	"github.com/elastic/libbeat/cfgfile"
 	"log"
 	"math"
@@ -18,6 +17,7 @@ const (
 	DefaultSpoolSize           uint64        = 1024
 	DefaultIdleTimeout         time.Duration = time.Second * 5
 	DefaultHarvesterBufferSize int           = 16 << 10 // 16384
+	DefaultTailOnRotate                      = false
 )
 
 type Config struct {
@@ -30,7 +30,6 @@ type FilebeatConfig struct {
 	CpuProfileFile      string
 	IdleTimeout         string `yaml:"idleTimeout"`
 	IdleTimeoutDuration time.Duration
-	TailOnRotate        bool
 	RegistryFile        string
 }
 
@@ -42,22 +41,8 @@ type FileConfig struct {
 	IgnoreOlderDuration   time.Duration
 	ScanFrequency         string `yaml:"scanFrequency"`
 	ScanFrequencyDuration time.Duration
-	HarvesterBufferSize   int
-}
-
-// TODO: Log is only used here now. Do we need it?
-const logflags = log.Ldate | log.Ltime | log.Lmicroseconds
-
-func init() {
-	log.SetFlags(logflags)
-}
-
-// TODO: Default options should be set as part of default config otherwise it always overwrites
-var CmdlineOptions = &FilebeatConfig{}
-
-func init() {
-	flag.BoolVar(&CmdlineOptions.TailOnRotate, "tail", CmdlineOptions.TailOnRotate, "always tail on log rotation -note: may skip entries ")
-	flag.BoolVar(&CmdlineOptions.TailOnRotate, "t", CmdlineOptions.TailOnRotate, "always tail on log rotation -note: may skip entries ")
+	HarvesterBufferSize   int  `yaml:"harvesterBufferSize"`
+	TailOnRotate          bool `yaml:"tailOnRotate"`
 }
 
 // getConfigFiles returns list of config files.

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ const (
 	DefaultIgnoreOlderDuration time.Duration = math.MaxInt64
 	DefaultScanFrequency       time.Duration = 10 * time.Second // 10 seconds
 	DefaultSpoolSize           uint64        = 1024
+	DefaultIdleTimeout         time.Duration = time.Second * 5
 )
 
 type Config struct {
@@ -27,7 +28,8 @@ type FilebeatConfig struct {
 	SpoolSize           uint64 `yaml:"spoolSize"`
 	HarvesterBufferSize int
 	CpuProfileFile      string
-	IdleTimeout         time.Duration
+	IdleTimeout         string `yaml:"idleTimeout"`
+	IdleTimeoutDuration         time.Duration
 	TailOnRotate        bool
 	Quiet               bool
 	RegistryFile        string
@@ -53,7 +55,6 @@ func init() {
 // TODO: Default options should be set as part of default config otherwise it always overwrites
 var CmdlineOptions = &FilebeatConfig{
 	HarvesterBufferSize: 16 << 10, // 16384
-	IdleTimeout:         time.Second * 5,
 }
 
 func init() {

--- a/config/config.go
+++ b/config/config.go
@@ -36,9 +36,9 @@ type FileConfig struct {
 	Paths                 []string
 	Fields                map[string]string
 	Input                 string
-	IgnoreOlder           string
+	IgnoreOlder           string `yaml:"ignoreOlder"`
 	IgnoreOlderDuration   time.Duration
-	ScanFrequency         string
+	ScanFrequency         string `yaml:"scanFrequency"`
 	ScanFrequencyDuration time.Duration
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,7 @@ type FilebeatConfig struct {
 	HarvesterBufferSize int
 	CpuProfileFile      string
 	IdleTimeout         string `yaml:"idleTimeout"`
-	IdleTimeoutDuration         time.Duration
+	IdleTimeoutDuration time.Duration
 	TailOnRotate        bool
 	Quiet               bool
 	RegistryFile        string

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ type Config struct {
 type FilebeatConfig struct {
 	Files               []FileConfig
 	SpoolSize           uint64 `yaml:"spoolSize"`
-	CpuProfileFile      string	// TODO: Still needed?
+	CpuProfileFile      string // TODO: Still needed?
 	IdleTimeout         string `yaml:"idleTimeout"`
 	IdleTimeoutDuration time.Duration
 	RegistryFile        string

--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,6 @@ type FilebeatConfig struct {
 	IdleTimeout         string `yaml:"idleTimeout"`
 	IdleTimeoutDuration time.Duration
 	TailOnRotate        bool
-	Quiet               bool
 	RegistryFile        string
 }
 
@@ -59,8 +58,6 @@ var CmdlineOptions = &FilebeatConfig{}
 func init() {
 	flag.BoolVar(&CmdlineOptions.TailOnRotate, "tail", CmdlineOptions.TailOnRotate, "always tail on log rotation -note: may skip entries ")
 	flag.BoolVar(&CmdlineOptions.TailOnRotate, "t", CmdlineOptions.TailOnRotate, "always tail on log rotation -note: may skip entries ")
-
-	flag.BoolVar(&CmdlineOptions.Quiet, "quiet", CmdlineOptions.Quiet, "operate in quiet mode - only emit errors to log")
 }
 
 // getConfigFiles returns list of config files.

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ const (
 	DefaultScanFrequency       time.Duration = 10 * time.Second // 10 seconds
 	DefaultSpoolSize           uint64        = 1024
 	DefaultIdleTimeout         time.Duration = time.Second * 5
+	DefaultHarvesterBufferSize int           = 16 << 10 // 16384
 )
 
 type Config struct {
@@ -26,7 +27,6 @@ type Config struct {
 type FilebeatConfig struct {
 	Files               []FileConfig
 	SpoolSize           uint64 `yaml:"spoolSize"`
-	HarvesterBufferSize int
 	CpuProfileFile      string
 	IdleTimeout         string `yaml:"idleTimeout"`
 	IdleTimeoutDuration time.Duration
@@ -43,6 +43,7 @@ type FileConfig struct {
 	IgnoreOlderDuration   time.Duration
 	ScanFrequency         string `yaml:"scanFrequency"`
 	ScanFrequencyDuration time.Duration
+	HarvesterBufferSize   int
 }
 
 // TODO: Log is only used here now. Do we need it?
@@ -53,14 +54,9 @@ func init() {
 }
 
 // TODO: Default options should be set as part of default config otherwise it always overwrites
-var CmdlineOptions = &FilebeatConfig{
-	HarvesterBufferSize: 16 << 10, // 16384
-}
+var CmdlineOptions = &FilebeatConfig{}
 
 func init() {
-	flag.IntVar(&CmdlineOptions.HarvesterBufferSize, "harvest-buffer-size", CmdlineOptions.HarvesterBufferSize, "harvester reader buffer size")
-	flag.IntVar(&CmdlineOptions.HarvesterBufferSize, "hb", CmdlineOptions.HarvesterBufferSize, "harvester reader buffer size")
-
 	flag.BoolVar(&CmdlineOptions.TailOnRotate, "tail", CmdlineOptions.TailOnRotate, "always tail on log rotation -note: may skip entries ")
 	flag.BoolVar(&CmdlineOptions.TailOnRotate, "t", CmdlineOptions.TailOnRotate, "always tail on log rotation -note: may skip entries ")
 

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ const (
 	DefaultRegistryFile                      = ".filebeat"
 	DefaultIgnoreOlderDuration time.Duration = math.MaxInt64
 	DefaultScanFrequency       time.Duration = 10 * time.Second // 10 seconds
+	DefaultSpoolSize           uint64        = 1024
 )
 
 type Config struct {
@@ -23,7 +24,7 @@ type Config struct {
 
 type FilebeatConfig struct {
 	Files               []FileConfig
-	SpoolSize           uint64
+	SpoolSize           uint64 `yaml:"spoolSize"`
 	HarvesterBufferSize int
 	CpuProfileFile      string
 	IdleTimeout         time.Duration
@@ -51,16 +52,11 @@ func init() {
 
 // TODO: Default options should be set as part of default config otherwise it always overwrites
 var CmdlineOptions = &FilebeatConfig{
-	SpoolSize:           1024,
 	HarvesterBufferSize: 16 << 10, // 16384
 	IdleTimeout:         time.Second * 5,
 }
 
 func init() {
-
-	flag.Uint64Var(&CmdlineOptions.SpoolSize, "spool-size", CmdlineOptions.SpoolSize, "event count spool threshold - forces network flush")
-	flag.Uint64Var(&CmdlineOptions.SpoolSize, "sv", CmdlineOptions.SpoolSize, "event count spool threshold - forces network flush")
-
 	flag.IntVar(&CmdlineOptions.HarvesterBufferSize, "harvest-buffer-size", CmdlineOptions.HarvesterBufferSize, "harvester reader buffer size")
 	flag.IntVar(&CmdlineOptions.HarvesterBufferSize, "hb", CmdlineOptions.HarvesterBufferSize, "harvester reader buffer size")
 

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ type Config struct {
 type FilebeatConfig struct {
 	Files               []FileConfig
 	SpoolSize           uint64 `yaml:"spoolSize"`
-	CpuProfileFile      string
+	CpuProfileFile      string	// TODO: Still needed?
 	IdleTimeout         string `yaml:"idleTimeout"`
 	IdleTimeoutDuration time.Duration
 	RegistryFile        string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,6 +19,8 @@ func TestReadConfig(t *testing.T) {
 
 	assert.Nil(t, err)
 
+	assert.Equal(t, uint64(1024), config.Filebeat.SpoolSize)
+
 	files := config.Filebeat.Files
 
 	// Check if multiple paths were read in
@@ -36,6 +38,22 @@ func TestReadConfig(t *testing.T) {
 	assert.Equal(t, "stdin", files[2].Input)
 	assert.Equal(t, 0, len(files[2].Paths))
 	assert.Equal(t, "", files[1].ScanFrequency)
+}
+
+func TestReadConfig2(t *testing.T) {
+	// Tests with different params from config file
+	absPath, err := filepath.Abs("../tests/files/")
+
+	assert.NotNil(t, absPath)
+	assert.Nil(t, err)
+
+	config := &Config{}
+
+	// Reads second config file
+	err = cfgfile.Read(config, absPath+"/config2.yml")
+	assert.Nil(t, err)
+
+	assert.Equal(t, uint64(0), config.Filebeat.SpoolSize)
 }
 
 func TestGetConfigFiles_File(t *testing.T) {

--- a/crawler/prospector.go
+++ b/crawler/prospector.go
@@ -87,8 +87,9 @@ func (p *Prospector) Run(spoolChan chan *input.FileEvent) {
 				Path:       path,
 				FileConfig: p.FileConfig,
 				// TODO: SpoolerChan is passed around, but could be part of prospector (init)
-				SpoolerChan: spoolChan,
-				BufferSize:  p.FileConfig.HarvesterBufferSize,
+				SpoolerChan:  spoolChan,
+				BufferSize:   p.FileConfig.HarvesterBufferSize,
+				TailOnRotate: p.FileConfig.TailOnRotate,
 			}
 
 			h.Start()

--- a/crawler/prospector.go
+++ b/crawler/prospector.go
@@ -62,6 +62,10 @@ func (p *Prospector) Init() error {
 		p.FileConfig.ScanFrequencyDuration = cfg.DefaultScanFrequency
 	}
 
+	if p.FileConfig.HarvesterBufferSize == 0 {
+		p.FileConfig.HarvesterBufferSize = cfg.DefaultHarvesterBufferSize
+	}
+
 	// Init list
 	p.prospectorList = make(map[string]ProspectorFileStat)
 
@@ -84,6 +88,7 @@ func (p *Prospector) Run(spoolChan chan *input.FileEvent) {
 				FileConfig: p.FileConfig,
 				// TODO: SpoolerChan is passed around, but could be part of prospector (init)
 				SpoolerChan: spoolChan,
+				BufferSize:  p.FileConfig.HarvesterBufferSize,
 			}
 
 			h.Start()

--- a/crawler/prospector_test.go
+++ b/crawler/prospector_test.go
@@ -13,6 +13,7 @@ func TestProspectorInit(t *testing.T) {
 		ScanFrequency:       "15s",
 		IgnoreOlder:         "100m",
 		HarvesterBufferSize: 100,
+		TailOnRotate:        true,
 	}
 
 	prospector := Prospector{
@@ -27,6 +28,7 @@ func TestProspectorInit(t *testing.T) {
 	assert.Equal(t, 100*time.Minute, prospector.FileConfig.IgnoreOlderDuration)
 	assert.Equal(t, 15*time.Second, prospector.FileConfig.ScanFrequencyDuration)
 	assert.Equal(t, 100, prospector.FileConfig.HarvesterBufferSize)
+	assert.Equal(t, true, prospector.FileConfig.TailOnRotate)
 }
 
 func TestProspectorInitEmpty(t *testing.T) {
@@ -63,6 +65,7 @@ func TestProspectorInitNotSet(t *testing.T) {
 	assert.Equal(t, config.DefaultIgnoreOlderDuration, prospector.FileConfig.IgnoreOlderDuration)
 	assert.Equal(t, config.DefaultScanFrequency, prospector.FileConfig.ScanFrequencyDuration)
 	assert.Equal(t, config.DefaultHarvesterBufferSize, prospector.FileConfig.HarvesterBufferSize)
+	assert.Equal(t, config.DefaultTailOnRotate, prospector.FileConfig.TailOnRotate)
 }
 
 func TestProspectorInitScanFrequency0(t *testing.T) {

--- a/crawler/prospector_test.go
+++ b/crawler/prospector_test.go
@@ -10,8 +10,9 @@ import (
 func TestProspectorInit(t *testing.T) {
 
 	fileConfig := config.FileConfig{
-		ScanFrequency: "15s",
-		IgnoreOlder:   "100m",
+		ScanFrequency:       "15s",
+		IgnoreOlder:         "100m",
+		HarvesterBufferSize: 100,
 	}
 
 	prospector := Prospector{
@@ -25,13 +26,15 @@ func TestProspectorInit(t *testing.T) {
 	// Predefined values expected
 	assert.Equal(t, 100*time.Minute, prospector.FileConfig.IgnoreOlderDuration)
 	assert.Equal(t, 15*time.Second, prospector.FileConfig.ScanFrequencyDuration)
+	assert.Equal(t, 100, prospector.FileConfig.HarvesterBufferSize)
 }
 
 func TestProspectorInitEmpty(t *testing.T) {
 
 	fileConfig := config.FileConfig{
-		ScanFrequency: "",
-		IgnoreOlder:   "",
+		ScanFrequency:       "",
+		IgnoreOlder:         "",
+		HarvesterBufferSize: 0,
 	}
 
 	prospector := Prospector{
@@ -43,6 +46,7 @@ func TestProspectorInitEmpty(t *testing.T) {
 	// Default values expected
 	assert.Equal(t, config.DefaultIgnoreOlderDuration, prospector.FileConfig.IgnoreOlderDuration)
 	assert.Equal(t, config.DefaultScanFrequency, prospector.FileConfig.ScanFrequencyDuration)
+	assert.Equal(t, config.DefaultHarvesterBufferSize, prospector.FileConfig.HarvesterBufferSize)
 }
 
 func TestProspectorInitNotSet(t *testing.T) {
@@ -58,6 +62,7 @@ func TestProspectorInitNotSet(t *testing.T) {
 	// Default values expected
 	assert.Equal(t, config.DefaultIgnoreOlderDuration, prospector.FileConfig.IgnoreOlderDuration)
 	assert.Equal(t, config.DefaultScanFrequency, prospector.FileConfig.ScanFrequencyDuration)
+	assert.Equal(t, config.DefaultHarvesterBufferSize, prospector.FileConfig.HarvesterBufferSize)
 }
 
 func TestProspectorInitScanFrequency0(t *testing.T) {

--- a/etc/filebeat.yml
+++ b/etc/filebeat.yml
@@ -6,8 +6,8 @@ filebeat:
     -
       # Paths that should be crawled and fetched
       paths:
-        #- /var/log/app*.log
         - /var/log/*.log
+
       # Type of the files. Based on this the way the file is read is decided. The different types cannot be mixed.
       #
       # Possible options are:
@@ -16,16 +16,22 @@ filebeat:
       # * meta: Reads new meta information on file change
       # * stdin: Reads the standard in
       type: log
+
       # Optional additional fields
       fields:
         level: debug
         review: 1
+
       # Ignore files which were modified more then the defined timespan in the past
       ignoreOlder:
+
       # Scan frequency in seconds.
       # How often these files should be checked for changes. In case it is set
       # to 0s, it is done as often as possible. Default: 10s
       scanFrequency: 10s
+
+      # Defines the buffer size every harvester uses when fetching the file
+      harvesterBufferSize: 16384
     -
       fields:
       paths:
@@ -42,7 +48,6 @@ filebeat:
   # Event count spool threshold - forces network flush if exceeded
   spoolSize: 1024
   idleTimeout: 5s
-  harvesterBufferSize:
   cpuProfileFile:
   tailOnRotate:
   quiet:

--- a/etc/filebeat.yml
+++ b/etc/filebeat.yml
@@ -21,11 +21,11 @@ filebeat:
         level: debug
         review: 1
       # Ignore files which were modified more then the defined timespan in the past
-      ignoreolder:
+      ignoreOlder:
       # Scan frequency in seconds.
       # How often these files should be checked for changes. In case it is set
       # to 0s, it is done as often as possible. Default: 10s
-      scanfrequency: 10s
+      scanFrequency: 10s
     -
       fields:
       paths:
@@ -33,7 +33,7 @@ filebeat:
       type: log
       # Regexp log line filter (not implemented yet)
       filter: "regexp"
-      ignoreolder: 24h
+      ignoreOlder: 24h
     -
       fields:
       type: stdin

--- a/etc/filebeat.yml
+++ b/etc/filebeat.yml
@@ -50,7 +50,6 @@ filebeat:
   idleTimeout: 5s
   cpuProfileFile:
   tailOnRotate:
-  quiet:
   registryfile: .filebeat
 
 

--- a/etc/filebeat.yml
+++ b/etc/filebeat.yml
@@ -32,6 +32,10 @@ filebeat:
 
       # Defines the buffer size every harvester uses when fetching the file
       harvesterBufferSize: 16384
+
+      # Always tail on log rotation. Disabled by default
+      # Note: This may skip entries
+      tailOnRotate: false
     -
       fields:
       paths:
@@ -49,7 +53,6 @@ filebeat:
   spoolSize: 1024
   idleTimeout: 5s
   cpuProfileFile:
-  tailOnRotate:
   registryfile: .filebeat
 
 

--- a/etc/filebeat.yml
+++ b/etc/filebeat.yml
@@ -39,7 +39,8 @@ filebeat:
       type: stdin
       paths:
         - "-"
-  spoolSize:
+  # Event count spool threshold - forces network flush if exceeded
+  spoolSize: 1024
   harvesterBufferSize:
   cpuProfileFile:
   idleTimeout:

--- a/etc/filebeat.yml
+++ b/etc/filebeat.yml
@@ -41,9 +41,9 @@ filebeat:
         - "-"
   # Event count spool threshold - forces network flush if exceeded
   spoolSize: 1024
+  idleTimeout: 5s
   harvesterBufferSize:
   cpuProfileFile:
-  idleTimeout:
   tailOnRotate:
   quiet:
   registryfile: .filebeat

--- a/harvester/harvester.go
+++ b/harvester/harvester.go
@@ -12,8 +12,8 @@ type Harvester struct {
 	Offset      int64
 	FinishChan  chan int64
 	SpoolerChan chan *input.FileEvent
-
-	file *os.File /* the file being watched */
+	BufferSize  int
+	file        *os.File /* the file being watched */
 }
 
 // Interface for the different harvester types

--- a/harvester/harvester.go
+++ b/harvester/harvester.go
@@ -7,13 +7,14 @@ import (
 )
 
 type Harvester struct {
-	Path        string /* the file path to harvest */
-	FileConfig  config.FileConfig
-	Offset      int64
-	FinishChan  chan int64
-	SpoolerChan chan *input.FileEvent
-	BufferSize  int
-	file        *os.File /* the file being watched */
+	Path         string /* the file path to harvest */
+	FileConfig   config.FileConfig
+	Offset       int64
+	FinishChan   chan int64
+	SpoolerChan  chan *input.FileEvent
+	BufferSize   int
+	TailOnRotate bool
+	file         *os.File /* the file being watched */
 }
 
 // Interface for the different harvester types

--- a/harvester/log.go
+++ b/harvester/log.go
@@ -35,7 +35,7 @@ func (h *Harvester) Harvest() {
 
 	h.initOffset()
 
-	reader := bufio.NewReaderSize(h.file, config.CmdlineOptions.HarvesterBufferSize) // 16kb buffer by default
+	reader := bufio.NewReaderSize(h.file, h.BufferSize)
 	buffer := new(bytes.Buffer)
 
 	var readTimeout = 10 * time.Second

--- a/harvester/log.go
+++ b/harvester/log.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/elastic/filebeat/config"
 	"github.com/elastic/filebeat/input"
 	"github.com/elastic/libbeat/logp"
 )
@@ -77,7 +76,7 @@ func (h *Harvester) initOffset() {
 
 	if h.Offset > 0 {
 		logp.Debug("harvester", "harvest: %q position:%d (offset snapshot:%d)", h.Path, h.Offset, offset)
-	} else if config.CmdlineOptions.TailOnRotate {
+	} else if h.TailOnRotate {
 		logp.Debug("harvester", "harvest: (tailing) %q (offset snapshot:%d)", h.Path, offset)
 	} else {
 		logp.Debug("harvester", "harvest: %q (offset snapshot:%d)", h.Path, offset)
@@ -90,7 +89,7 @@ func (h *Harvester) initOffset() {
 func (h *Harvester) setFileOffset() {
 	if h.Offset > 0 {
 		h.file.Seek(h.Offset, os.SEEK_SET)
-	} else if config.CmdlineOptions.TailOnRotate {
+	} else if h.TailOnRotate {
 		h.file.Seek(0, os.SEEK_END)
 	} else {
 		h.file.Seek(0, os.SEEK_SET)

--- a/tests/files/config.yml
+++ b/tests/files/config.yml
@@ -14,6 +14,8 @@ filebeat:
         type: log
       ignoreOlder: 24h
       scanFrequency: 10s
+      harvesterBufferSize: 5000
+
     -
       fields:
       paths:
@@ -24,7 +26,6 @@ filebeat:
       input: stdin
       # Paths is not required
   spoolSize: 1024
-  harvesterBufferSize:
   cpuProfileFile:
   idleTimeout: 5s
   tailOnRotate:

--- a/tests/files/config.yml
+++ b/tests/files/config.yml
@@ -23,7 +23,7 @@ filebeat:
       fields:
       input: stdin
       # Paths is not required
-  spoolSize:
+  spoolSize: 1024
   harvesterBufferSize:
   cpuProfileFile:
   idleTimeout:

--- a/tests/files/config.yml
+++ b/tests/files/config.yml
@@ -26,7 +26,7 @@ filebeat:
   spoolSize: 1024
   harvesterBufferSize:
   cpuProfileFile:
-  idleTimeout:
+  idleTimeout: 5s
   tailOnRotate:
   quiet:
 

--- a/tests/files/config.yml
+++ b/tests/files/config.yml
@@ -12,8 +12,8 @@ filebeat:
         level: debug
         review: 1
         type: log
-      ignoreolder: 24h
-      scanfrequency: 10s
+      ignoreOlder: 24h
+      scanFrequency: 10s
     -
       fields:
       paths:

--- a/tests/files/config.yml
+++ b/tests/files/config.yml
@@ -29,7 +29,6 @@ filebeat:
   cpuProfileFile:
   idleTimeout: 5s
   tailOnRotate:
-  quiet:
 
 
 # Additional stuff we should be ignore

--- a/tests/files/config2.yml
+++ b/tests/files/config2.yml
@@ -4,3 +4,5 @@ filebeat:
       paths:
         - /var/log/*.log
       input: log
+
+  spoolSize:

--- a/tests/integration/config/filebeat.yml.j2
+++ b/tests/integration/config/filebeat.yml.j2
@@ -14,7 +14,6 @@ filebeat:
   cpuProfileFile:
   idleTimeout: 5s
   tailOnRotate:
-  quiet:
   registryfile: {{ fb.working_dir + '/' }}.filebeat
 
 

--- a/tests/integration/config/filebeat.yml.j2
+++ b/tests/integration/config/filebeat.yml.j2
@@ -9,8 +9,8 @@ filebeat:
       input: log
       scanfrequency: 1s
       ignoreOlder: "{{ignoreOlder}}"
+      harvesterBufferSize:
   spoolSize:
-  harvesterBufferSize:
   cpuProfileFile:
   idleTimeout: 5s
   tailOnRotate:

--- a/tests/integration/config/filebeat.yml.j2
+++ b/tests/integration/config/filebeat.yml.j2
@@ -12,7 +12,7 @@ filebeat:
   spoolSize:
   harvesterBufferSize:
   cpuProfileFile:
-  idleTimeout:
+  idleTimeout: 5s
   tailOnRotate:
   quiet:
   registryfile: {{ fb.working_dir + '/' }}.filebeat

--- a/tests/integration/config/filebeat.yml.j2
+++ b/tests/integration/config/filebeat.yml.j2
@@ -7,7 +7,7 @@ filebeat:
         - "{{ path }}"
       # Type of the files. Annotated in every documented
       type: log
-      scanfrequency: 1s
+      scanFrequency: 1s
   spoolSize:
   harvesterBufferSize:
   cpuProfileFile:

--- a/tests/integration/test_prospector.py
+++ b/tests/integration/test_prospector.py
@@ -16,7 +16,7 @@ class Test(TestCase):
         """
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
-            ignoreolder="1s"
+            ignoreOlder="1s"
         )
 
         os.mkdir(self.working_dir + "/log/")
@@ -49,7 +49,7 @@ class Test(TestCase):
         """
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
-            ignoreolder="15s"
+            ignoreOlder="15s"
         )
 
         os.mkdir(self.working_dir + "/log/")


### PR DESCRIPTION
The following config options were refactored and removed from command line options:
* spoolSize
* idleTimeout
* harvesterBufferSize
* tailOnRotate