### PR TITLE
Speed improvements for the integration tests

### DIFF
--- a/tests/integration/filebeat.py
+++ b/tests/integration/filebeat.py
@@ -5,8 +5,6 @@ import os
 import shutil
 import json
 import time
-import json
-import sys
 from datetime import datetime, timedelta
 
 
@@ -50,10 +48,10 @@ class Proc(object):
 class TestCase(unittest.TestCase):
 
     def run_filebeat(self, cmd="../../filebeat.test",
-                       config="filebeat.yml",
-                       output="filebeat.log",
-                       extra_args=[],
-                       debug_selectors=[]):
+                     config="filebeat.yml",
+                     output="filebeat.log",
+                     extra_args=[],
+                     debug_selectors=[]):
         """
         Executes filebeat
         Waits for the process to finish before returning to
@@ -68,7 +66,8 @@ class TestCase(unittest.TestCase):
                      "-integration",
                      "-v",
                      "-d", "*",
-                     "-test.coverprofile", os.path.join(self.working_dir, "coverage.cov")
+                     "-test.coverprofile",
+                     os.path.join(self.working_dir, "coverage.cov")
                      ])
         if extra_args:
             args.extend(extra_args)
@@ -83,11 +82,11 @@ class TestCase(unittest.TestCase):
             return proc.wait()
 
     def start_filebeat(self,
-                         cmd="../../filebeat.test",
-                         config="filebeat.yml",
-                         output="filebeat.log",
-                         extra_args=[],
-                         debug_selectors=[]):
+                       cmd="../../filebeat.test",
+                       config="filebeat.yml",
+                       output="filebeat.log",
+                       extra_args=[],
+                       debug_selectors=[]):
         """
         Starts filebeat and returns the process handle. The
         caller is responsible for stopping / waiting for the
@@ -99,7 +98,8 @@ class TestCase(unittest.TestCase):
                 "-integration",
                 "-v",
                 "-d", "*",
-                "-test.coverprofile", os.path.join(self.working_dir, "coverage.cov")
+                "-test.coverprofile",
+                os.path.join(self.working_dir, "coverage.cov")
                 ]
         if extra_args:
             args.extend(extra_args)
@@ -245,7 +245,7 @@ class TestCase(unittest.TestCase):
     def get_dot_filebeat(self):
         # Returns content of the .filebeat file
         dotFilebeat = self.working_dir + '/.filebeat'
-        assert os.path.isfile(dotFilebeat) == True
+        assert os.path.isfile(dotFilebeat) is True
 
         with open(dotFilebeat) as file:
             return json.load(file)
@@ -253,15 +253,15 @@ class TestCase(unittest.TestCase):
     def get_filebeat_output(self):
         # Returns content of the filebeat output file as json array
         outputFile = self.working_dir + '/output/filebeat'
-        assert os.path.isfile(outputFile) == True
+        assert os.path.isfile(outputFile) is True
 
         data = []
 
         with open(outputFile) as file:
             while True:
                 line = file.readline()
-                if not line: break
+                if not line:
+                    break
 
                 data.append(json.loads(line))
             return data
-

--- a/tests/integration/test_crawler.py
+++ b/tests/integration/test_crawler.py
@@ -3,19 +3,22 @@ from filebeat import TestCase
 import os
 import time
 
+
 # Additional tests to be added:
 # * Check what happens when file renamed -> no recrawling should happen
 # * Check if file descriptor is "closed" when file disappears
 class Test(TestCase):
     def test_fetched_lines(self):
-        # Checks if all lines are read from the log file
+        """
+        Checks if all lines are read from the log file.
+        """
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*"
         )
         os.mkdir(self.working_dir + "/log/")
 
-        testfile =  self.working_dir + "/log/test.log"
+        testfile = self.working_dir + "/log/test.log"
         file = open(testfile, 'w')
 
         iterations = 80
@@ -23,14 +26,18 @@ class Test(TestCase):
             file.write("hello world" + str(n))
             file.write("\n")
 
-
         file.close()
 
         filebeat = self.start_filebeat()
 
+        self.wait_until(
+            lambda: self.log_contains(
+                "Registrar: processing 80 events"),
+            max_timeout=10)
+
         # TODO: Find better solution when filebeat did crawl the file
-        # Idea: Special flag to filebeat so that filebeat is only doing and crawl and then finishes
-        time.sleep(10)
+        # Idea: Special flag to filebeat so that filebeat is only doing and
+        # crawl and then finishes
         filebeat.kill_and_wait()
 
         i = 0
@@ -43,16 +50,17 @@ class Test(TestCase):
         # Check that output file has the same number of lines as the log file
         assert iterations == i
 
-
     def test_unfinished_line(self):
-        # Checks that if a line does not have a line ending, is is not read yet
+        """
+        Checks that if a line does not have a line ending, is is not read yet.
+        """
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*"
         )
         os.mkdir(self.working_dir + "/log/")
 
-        testfile =  self.working_dir + "/log/test.log"
+        testfile = self.working_dir + "/log/test.log"
         file = open(testfile, 'w')
 
         iterations = 80
@@ -60,16 +68,21 @@ class Test(TestCase):
             file.write("hello world" + str(n))
             file.write("\n")
 
-        # An additional line is written to the log file. This line should not be read
-        # as there is no finishing \n or \r
+        # An additional line is written to the log file. This line should not
+        # be read as there is no finishing \n or \r
         file.write("unfinished line")
 
         file.close()
 
         filebeat = self.start_filebeat()
 
-        # TODO: Find better solution when filebeat did crawl the file
-        time.sleep(10)
+        self.wait_until(
+            lambda: self.log_contains(
+                "Registrar: processing 80 events"),
+            max_timeout=10)
+
+        # Give it more time to make sure it doesn't read the unfinished line
+        time.sleep(2)
         filebeat.kill_and_wait()
 
         i = 0
@@ -82,16 +95,17 @@ class Test(TestCase):
         # Check that output file has the same number of lines as the log file
         assert iterations == i
 
-
     def test_file_renaming(self):
-        # Makes sure that when a file is renamed, the content is not read again.
+        """
+        Makes sure that when a file is renamed, the content is not read again.
+        """
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*"
         )
         os.mkdir(self.working_dir + "/log/")
 
-        testfile1 =  self.working_dir + "/log/test-old.log"
+        testfile1 = self.working_dir + "/log/test-old.log"
         file = open(testfile1, 'w')
 
         iterations = 5
@@ -103,24 +117,30 @@ class Test(TestCase):
 
         filebeat = self.start_filebeat()
 
-        # Let it read the file
-        time.sleep(5)
+        self.wait_until(
+            lambda: self.log_contains(
+                "Registrar: processing 5 events"),
+            max_timeout=10)
 
         # Rename the file (no new file created)
         testfile2 = self.working_dir + "/log/test-new.log"
         os.rename(testfile1, testfile2)
         file = open(testfile2, 'a')
 
-        iterations = 5
+        # using 6 events to have a separate log line that we can
+        # grep for.
+        iterations = 6
         for n in range(0, iterations):
             file.write("new file")
             file.write("\n")
 
         file.close()
 
-
-        # let it read the new file
-        time.sleep(20)
+        # expecting 6 more events
+        self.wait_until(
+            lambda: self.log_contains(
+                "Registrar: processing 6 events"),
+            max_timeout=20)
 
         filebeat.kill_and_wait()
 
@@ -132,17 +152,19 @@ class Test(TestCase):
                 pass
 
         # Make sure all 10 lines were read
-        assert i == 10
+        assert i == 11
 
     def test_file_disappear(self):
-        # Checks that filebeat keeps running in case a log files is deleted
+        """
+        Checks that filebeat keeps running in case a log files is deleted
+        """
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*"
         )
         os.mkdir(self.working_dir + "/log/")
 
-        testfile =  self.working_dir + "/log/test.log"
+        testfile = self.working_dir + "/log/test.log"
         file = open(testfile, 'w')
 
         iterations = 5
@@ -155,22 +177,28 @@ class Test(TestCase):
         filebeat = self.start_filebeat()
 
         # Let it read the file
-        time.sleep(5)
+        self.wait_until(
+            lambda: self.log_contains(
+                "Registrar: processing 5 events"),
+            max_timeout=10)
         os.remove(testfile)
-        time.sleep(5)
 
         # Create new file to check if new file is picked up
-        testfile2 =  self.working_dir + "/log/test2.log"
+        testfile2 = self.working_dir + "/log/test2.log"
         file = open(testfile2, 'w')
 
-        iterations = 5
+        iterations = 6
         for n in range(0, iterations):
             file.write("new file")
             file.write("\n")
 
         file.close()
 
-        time.sleep(5)
+        # Let it read the file
+        self.wait_until(
+            lambda: self.log_contains(
+                "Registrar: processing 6 events"),
+            max_timeout=10)
 
         filebeat.kill_and_wait()
 
@@ -182,18 +210,19 @@ class Test(TestCase):
         # Make sure output has 10 entries
         output = self.get_filebeat_output()
 
-        assert len(output) == 2 * 5
-
+        assert len(output) == 5 + 6
 
     def test_file_disappear_appear(self):
-        # Checks that filebeat keeps running in case a log files is deleted
+        """
+        Checks that filebeat keeps running in case a log files is deleted
+        """
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*"
         )
         os.mkdir(self.working_dir + "/log/")
 
-        testfile =  self.working_dir + "/log/test.log"
+        testfile = self.working_dir + "/log/test.log"
         file = open(testfile, 'w')
 
         iterations = 5
@@ -206,31 +235,38 @@ class Test(TestCase):
         filebeat = self.start_filebeat()
 
         # Let it read the file
-        time.sleep(5)
+        self.wait_until(
+            lambda: self.log_contains(
+                "Registrar: processing 5 events"),
+            max_timeout=10)
         os.remove(testfile)
         time.sleep(5)
 
-        # Create new file with same to see if it is picked up
+        # Create new file with same name to see if it is picked up
         file = open(testfile, 'w')
 
-        iterations = 5
+        iterations = 6
         for n in range(0, iterations):
             file.write("new file")
             file.write("\n")
 
         file.close()
 
-        time.sleep(5)
+        # Let it read the file
+        self.wait_until(
+            lambda: self.log_contains(
+                "Registrar: processing 6 events"),
+            max_timeout=10)
 
         filebeat.kill_and_wait()
 
         data = self.get_dot_filebeat()
 
-        # Make sure new file was picked up. As it has the same file name, only one entry exists
+        # Make sure new file was picked up. As it has the same file name,
+        # only one entry exists
         assert len(data) == 1
 
-        # Make sure output has 10 entries, the new file was started from scratch
+        # Make sure output has 11 entries, the new file was started
+        # from scratch
         output = self.get_filebeat_output()
-        assert len(output) == 2 * 5
-
-
+        assert len(output) == 5 + 6

--- a/tests/integration/test_crawler.py
+++ b/tests/integration/test_crawler.py
@@ -33,7 +33,7 @@ class Test(TestCase):
         self.wait_until(
             lambda: self.log_contains(
                 "Registrar: processing 80 events"),
-            max_timeout=10)
+            max_timeout=15)
 
         # TODO: Find better solution when filebeat did crawl the file
         # Idea: Special flag to filebeat so that filebeat is only doing and
@@ -79,7 +79,7 @@ class Test(TestCase):
         self.wait_until(
             lambda: self.log_contains(
                 "Registrar: processing 80 events"),
-            max_timeout=10)
+            max_timeout=15)
 
         # Give it more time to make sure it doesn't read the unfinished line
         time.sleep(2)
@@ -120,7 +120,7 @@ class Test(TestCase):
         self.wait_until(
             lambda: self.log_contains(
                 "Registrar: processing 5 events"),
-            max_timeout=10)
+            max_timeout=15)
 
         # Rename the file (no new file created)
         testfile2 = self.working_dir + "/log/test-new.log"
@@ -180,7 +180,7 @@ class Test(TestCase):
         self.wait_until(
             lambda: self.log_contains(
                 "Registrar: processing 5 events"),
-            max_timeout=10)
+            max_timeout=15)
         os.remove(testfile)
 
         # Create new file to check if new file is picked up
@@ -198,7 +198,7 @@ class Test(TestCase):
         self.wait_until(
             lambda: self.log_contains(
                 "Registrar: processing 6 events"),
-            max_timeout=10)
+            max_timeout=15)
 
         filebeat.kill_and_wait()
 
@@ -238,7 +238,7 @@ class Test(TestCase):
         self.wait_until(
             lambda: self.log_contains(
                 "Registrar: processing 5 events"),
-            max_timeout=10)
+            max_timeout=15)
         os.remove(testfile)
         time.sleep(5)
 
@@ -256,7 +256,7 @@ class Test(TestCase):
         self.wait_until(
             lambda: self.log_contains(
                 "Registrar: processing 6 events"),
-            max_timeout=10)
+            max_timeout=15)
 
         filebeat.kill_and_wait()
 

--- a/tests/integration/test_prospector.py
+++ b/tests/integration/test_prospector.py
@@ -16,8 +16,7 @@ class Test(TestCase):
         """
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
-            ignoreolder="1s",
-            debug_selectors=["ignoreolder", "publish"]
+            ignoreolder="1s"
         )
 
         os.mkdir(self.working_dir + "/log/")
@@ -50,8 +49,7 @@ class Test(TestCase):
         """
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
-            ignoreolder="15s",
-            debug_selectors=["ignoreolder", "registrar"]
+            ignoreolder="15s"
         )
 
         os.mkdir(self.working_dir + "/log/")
@@ -66,7 +64,6 @@ class Test(TestCase):
 
         proc = self.start_filebeat()
 
-        # wait for the "Skipping file" log message
         self.wait_until(
             lambda: self.log_contains(
                 "Registrar: processing 5 events"),

--- a/tests/integration/test_prospector.py
+++ b/tests/integration/test_prospector.py
@@ -38,7 +38,7 @@ class Test(TestCase):
         self.wait_until(
             lambda: self.log_contains(
                 "Skipping file (older than ignore older of 1s):"),
-            max_timeout=3)
+            max_timeout=10)
 
         proc.kill_and_wait()
 
@@ -67,7 +67,7 @@ class Test(TestCase):
         self.wait_until(
             lambda: self.log_contains(
                 "Registrar: processing 5 events"),
-            max_timeout=5)
+            max_timeout=10)
 
         proc.kill_and_wait()
 

--- a/tests/integration/test_registrar.py
+++ b/tests/integration/test_registrar.py
@@ -1,27 +1,27 @@
 from filebeat import TestCase
 
 import os
-import time
-import json
 
 # Additional tests: to be implemented
 # * Check if registrar file can be configured, set config param
 # * Check "updating" of registrar file
 # * Check what happens when registrar file is deleted
 
+
 class Test(TestCase):
 
     def test_registrar_file_content(self):
-        # Check if registrar file is created correctly and content is as expected
+        """
+        Check if registrar file is created correctly and content is as expected
+        """
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*"
         )
         os.mkdir(self.working_dir + "/log/")
 
-        testfile =  self.working_dir + "/log/test.log"
+        testfile = self.working_dir + "/log/test.log"
         file = open(testfile, 'w')
-
 
         iterations = 5
         file.write(iterations * "hello world\n")
@@ -30,7 +30,10 @@ class Test(TestCase):
 
         filebeat = self.start_filebeat()
 
-        time.sleep(10)
+        self.wait_until(
+            lambda: self.log_contains(
+                "Registrar: processing 5 events"),
+            max_timeout=10)
         filebeat.kill_and_wait()
 
         # Check that file exist
@@ -38,7 +41,8 @@ class Test(TestCase):
 
         # Check that offset is set correctly
         logFileAbs = os.path.abspath(testfile)
-        assert data[logFileAbs]['offset'] == iterations * (11 + 1)   # Hello world text plus newline
+        assert data[logFileAbs]['offset'] == \
+            iterations * (11 + 1)   # Hello world text plus newline
 
         # Check that right source field is inside
         assert data[logFileAbs]['source'] == logFileAbs
@@ -55,34 +59,37 @@ class Test(TestCase):
         assert len(data) == 1
         assert len(data[logFileAbs]) == 4
 
-
     def test_registrar_files(self):
-        # Check that multiple files are put into registrar file
+        """
+        Check that multiple files are put into registrar file
+        """
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*"
         )
         os.mkdir(self.working_dir + "/log/")
 
-        testfile1 =  self.working_dir + "/log/test1.log"
-        testfile2 =  self.working_dir + "/log/test2.log"
+        testfile1 = self.working_dir + "/log/test1.log"
+        testfile2 = self.working_dir + "/log/test2.log"
         file1 = open(testfile1, 'w')
         file2 = open(testfile2, 'w')
 
         iterations = 5
         for n in range(0, iterations):
-            file1.write("hello world") # 11 chars
-            file1.write("\n") # 1 char
-            file2.write("goodbye world") # 11 chars
-            file2.write("\n") # 1 char
-
+            file1.write("hello world")  # 11 chars
+            file1.write("\n")  # 1 char
+            file2.write("goodbye world")  # 11 chars
+            file2.write("\n")  # 1 char
 
         file1.close()
         file2.close()
 
         filebeat = self.start_filebeat()
 
-        time.sleep(10)
+        self.wait_until(
+            lambda: self.log_contains(
+                "Registrar: processing 10 events"),
+            max_timeout=10)
         filebeat.kill_and_wait()
 
         # Check that file exist
@@ -90,4 +97,3 @@ class Test(TestCase):
 
         # Check that 2 files are port of the registrar file
         assert len(data) == 2
-

--- a/tests/integration/test_registrar.py
+++ b/tests/integration/test_registrar.py
@@ -33,7 +33,7 @@ class Test(TestCase):
         self.wait_until(
             lambda: self.log_contains(
                 "Registrar: processing 5 events"),
-            max_timeout=10)
+            max_timeout=15)
         filebeat.kill_and_wait()
 
         # Check that file exist
@@ -89,7 +89,7 @@ class Test(TestCase):
         self.wait_until(
             lambda: self.log_contains(
                 "Registrar: processing 10 events"),
-            max_timeout=10)
+            max_timeout=15)
         filebeat.kill_and_wait()
 
         # Check that file exist


### PR DESCRIPTION
Done by replaced sleeps with waiting for log lines to appear. This should also make things less sensitive to timing issues, because I increased most max_timeouts.

The speed improvement on my laptop is going from 75s to 45s. Not huge, but useful.

Also refactoring the code to respect PEP8 and to avoid code duplication.
