### PR TITLE
Use the read_output in integration tests

### DIFF
--- a/tests/integration/filebeat.py
+++ b/tests/integration/filebeat.py
@@ -127,8 +127,6 @@ class TestCase(unittest.TestCase):
                                                  []))
         self.all_have_fields(jsons, ["timestamp", "type",
                                      "shipper", "count"])
-        # TODO: add the list of expected fields
-        # self.all_fields_are_expected(jsons, self.expected_fields)
         return jsons
 
     def copy_files(self, files, source_dir="files/"):
@@ -249,19 +247,3 @@ class TestCase(unittest.TestCase):
 
         with open(dotFilebeat) as file:
             return json.load(file)
-
-    def get_filebeat_output(self):
-        # Returns content of the filebeat output file as json array
-        outputFile = self.working_dir + '/output/filebeat'
-        assert os.path.isfile(outputFile) is True
-
-        data = []
-
-        with open(outputFile) as file:
-            while True:
-                line = file.readline()
-                if not line:
-                    break
-
-                data.append(json.loads(line))
-            return data

--- a/tests/integration/test_crawler.py
+++ b/tests/integration/test_crawler.py
@@ -40,15 +40,10 @@ class Test(TestCase):
         # crawl and then finishes
         filebeat.kill_and_wait()
 
-        i = 0
-
-        # Count lines of filebeat generated file
-        with open(self.working_dir + "/output/filebeat") as f:
-            for i, l in enumerate(f, 1):
-                pass
+        output = self.read_output()
 
         # Check that output file has the same number of lines as the log file
-        assert iterations == i
+        assert iterations == len(output)
 
     def test_unfinished_line(self):
         """
@@ -85,15 +80,10 @@ class Test(TestCase):
         time.sleep(2)
         filebeat.kill_and_wait()
 
-        i = 0
-
-        # Count lines of filebeat generated file
-        with open(self.working_dir + "/output/filebeat") as f:
-            for i, l in enumerate(f, 1):
-                pass
+        output = self.read_output()
 
         # Check that output file has the same number of lines as the log file
-        assert iterations == i
+        assert iterations == len(output)
 
     def test_file_renaming(self):
         """
@@ -144,15 +134,10 @@ class Test(TestCase):
 
         filebeat.kill_and_wait()
 
-        i = 0
+        output = self.read_output()
 
-        # Count lines of filebeat generated file
-        with open(self.working_dir + "/output/filebeat") as f:
-            for i, l in enumerate(f, 1):
-                pass
-
-        # Make sure all 10 lines were read
-        assert i == 11
+        # Make sure all 11 lines were read
+        assert len(output) == 11
 
     def test_file_disappear(self):
         """
@@ -208,7 +193,7 @@ class Test(TestCase):
         assert len(data) == 2
 
         # Make sure output has 10 entries
-        output = self.get_filebeat_output()
+        output = self.read_output()
 
         assert len(output) == 5 + 6
 
@@ -268,5 +253,5 @@ class Test(TestCase):
 
         # Make sure output has 11 entries, the new file was started
         # from scratch
-        output = self.get_filebeat_output()
+        output = self.read_output()
         assert len(output) == 5 + 6


### PR DESCRIPTION
This replaces manually reading the files and the get_filebeat_output
method which did the mostly same thing.