### PR TITLE
Refactor files config to prospectors config

### DIFF
--- a/beat/filebeat.go
+++ b/beat/filebeat.go
@@ -95,7 +95,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	}
 
 	registrar.LoadState(crawler.Files)
-	crawler.Start(fb.FbConfig.Filebeat.Files, persist, fb.SpoolChan)
+	crawler.Start(fb.FbConfig.Filebeat.Prospectors, persist, fb.SpoolChan)
 
 	// Start spooler: Harvesters dump events into the spooler.
 	go fb.startSpooler(cfg.CmdlineOptions)

--- a/changelog.md
+++ b/changelog.md
@@ -48,6 +48,7 @@ Questions:
 * What should we do about multiple configs? Just provide some docs? https://github.com/elastic/logstash-forwarder/issues/136 currently working with -c for beat -config for dirs
 * Command line config option -config was renamed to configDir. Should also be introduced as config file param in case we want to keep it
 * Rethink dead-time: https://github.com/elastic/logstash-forwarder/issues/460
+* files config was renamed to prospectors as this makes more sense
 
 Notes:
 * Should every config entry have a name -> make it possible to know from which config entry something comes.

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 }
 
 type FilebeatConfig struct {
-	Files               []FileConfig
+	Prospectors               []ProspectorConfig
 	SpoolSize           uint64
 	HarvesterBufferSize int
 	CpuProfileFile      string
@@ -32,7 +32,7 @@ type FilebeatConfig struct {
 	RegistryFile        string
 }
 
-type FileConfig struct {
+type ProspectorConfig struct {
 	Paths                 []string
 	Fields                map[string]string
 	Input                 string
@@ -108,7 +108,7 @@ func mergeConfigFiles(configFiles []string, config *Config) error {
 		tmpConfig := &Config{}
 		cfgfile.Read(tmpConfig, file)
 
-		config.Filebeat.Files = append(config.Filebeat.Files, tmpConfig.Filebeat.Files...)
+		config.Filebeat.Prospectors = append(config.Filebeat.Prospectors, tmpConfig.Filebeat.Prospectors...)
 	}
 
 	return nil
@@ -129,7 +129,7 @@ func (config *Config) FetchConfigs(path string) {
 		log.Fatal("Error merging config files: ", err)
 	}
 
-	if len(config.Filebeat.Files) == 0 {
+	if len(config.Filebeat.Prospectors) == 0 {
 		log.Fatalf("No paths given. What files do you want me to watch?")
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,6 @@ type FilebeatConfig struct {
 	CpuProfileFile      string // TODO: Still needed?
 	IdleTimeout         string `yaml:"idleTimeout"`
 	IdleTimeoutDuration time.Duration
-	Quiet               bool
 	RegistryFile        string
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,7 +19,7 @@ func TestReadConfig(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	files := config.Filebeat.Files
+	files := config.Filebeat.Prospectors
 
 	// Check if multiple paths were read in
 	assert.Equal(t, 3, len(files))
@@ -106,5 +106,5 @@ func TestMergeConfigFiles(t *testing.T) {
 	config := &Config{}
 	mergeConfigFiles(files, config)
 
-	assert.Equal(t, 4, len(config.Filebeat.Files))
+	assert.Equal(t, 4, len(config.Filebeat.Prospectors))
 }

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -29,7 +29,7 @@ type Crawler struct {
 	Persist chan *input.FileState
 }
 
-func (crawler *Crawler) Start(files []config.FileConfig, persist map[string]*input.FileState,
+func (crawler *Crawler) Start(files []config.ProspectorConfig, persist map[string]*input.FileState,
 	eventChan chan *input.FileEvent) {
 
 	pendingProspectorCnt := 0
@@ -40,7 +40,7 @@ func (crawler *Crawler) Start(files []config.FileConfig, persist map[string]*inp
 		logp.Debug("prospector", "File Config: %v", fileconfig)
 
 		prospector := &Prospector{
-			FileConfig: fileconfig,
+			ProspectorConfig: fileconfig,
 			crawler:    crawler,
 		}
 

--- a/crawler/prospector_test.go
+++ b/crawler/prospector_test.go
@@ -9,13 +9,13 @@ import (
 
 func TestProspectorInit(t *testing.T) {
 
-	fileConfig := config.FileConfig{
+	prospectorConfig := config.ProspectorConfig{
 		ScanFrequency: "15s",
 		IgnoreOlder:   "100m",
 	}
 
 	prospector := Prospector{
-		FileConfig: fileConfig,
+		ProspectorConfig: prospectorConfig,
 	}
 
 	assert.NotNil(t, prospector)
@@ -23,68 +23,68 @@ func TestProspectorInit(t *testing.T) {
 	prospector.Init()
 
 	// Predefined values expected
-	assert.Equal(t, 100*time.Minute, prospector.FileConfig.IgnoreOlderDuration)
-	assert.Equal(t, 15*time.Second, prospector.FileConfig.ScanFrequencyDuration)
+	assert.Equal(t, 100*time.Minute, prospector.ProspectorConfig.IgnoreOlderDuration)
+	assert.Equal(t, 15*time.Second, prospector.ProspectorConfig.ScanFrequencyDuration)
 }
 
 func TestProspectorInitEmpty(t *testing.T) {
 
-	fileConfig := config.FileConfig{
+	prospectorConfig := config.ProspectorConfig{
 		ScanFrequency: "",
 		IgnoreOlder:   "",
 	}
 
 	prospector := Prospector{
-		FileConfig: fileConfig,
+		ProspectorConfig: prospectorConfig,
 	}
 
 	prospector.Init()
 
 	// Default values expected
-	assert.Equal(t, config.DefaultIgnoreOlderDuration, prospector.FileConfig.IgnoreOlderDuration)
-	assert.Equal(t, config.DefaultScanFrequency, prospector.FileConfig.ScanFrequencyDuration)
+	assert.Equal(t, config.DefaultIgnoreOlderDuration, prospector.ProspectorConfig.IgnoreOlderDuration)
+	assert.Equal(t, config.DefaultScanFrequency, prospector.ProspectorConfig.ScanFrequencyDuration)
 }
 
 func TestProspectorInitNotSet(t *testing.T) {
 
-	fileConfig := config.FileConfig{}
+	prospectorConfig := config.ProspectorConfig{}
 
 	prospector := Prospector{
-		FileConfig: fileConfig,
+		ProspectorConfig: prospectorConfig,
 	}
 
 	prospector.Init()
 
 	// Default values expected
-	assert.Equal(t, config.DefaultIgnoreOlderDuration, prospector.FileConfig.IgnoreOlderDuration)
-	assert.Equal(t, config.DefaultScanFrequency, prospector.FileConfig.ScanFrequencyDuration)
+	assert.Equal(t, config.DefaultIgnoreOlderDuration, prospector.ProspectorConfig.IgnoreOlderDuration)
+	assert.Equal(t, config.DefaultScanFrequency, prospector.ProspectorConfig.ScanFrequencyDuration)
 }
 
 func TestProspectorInitScanFrequency0(t *testing.T) {
 
-	fileConfig := config.FileConfig{
+	prospectorConfig := config.ProspectorConfig{
 		ScanFrequency: "0s",
 	}
 
 	prospector := Prospector{
-		FileConfig: fileConfig,
+		ProspectorConfig: prospectorConfig,
 	}
 
 	prospector.Init()
 
 	var zero time.Duration = 0
 	// 0 expected
-	assert.Equal(t, zero, prospector.FileConfig.ScanFrequencyDuration)
+	assert.Equal(t, zero, prospector.ProspectorConfig.ScanFrequencyDuration)
 }
 
 func TestProspectorInitInvalidScanFrequency(t *testing.T) {
 
-	fileConfig := config.FileConfig{
+	prospectorConfig := config.ProspectorConfig{
 		ScanFrequency: "abc",
 	}
 
 	prospector := Prospector{
-		FileConfig: fileConfig,
+		ProspectorConfig: prospectorConfig,
 	}
 
 	err := prospector.Init()
@@ -93,12 +93,12 @@ func TestProspectorInitInvalidScanFrequency(t *testing.T) {
 
 func TestProspectorInitInvalidIgnoreOlder(t *testing.T) {
 
-	fileConfig := config.FileConfig{
+	prospectorConfig := config.ProspectorConfig{
 		IgnoreOlder: "abc",
 	}
 
 	prospector := Prospector{
-		FileConfig: fileConfig,
+		ProspectorConfig: prospectorConfig,
 	}
 
 	err := prospector.Init()

--- a/etc/filebeat.yml
+++ b/etc/filebeat.yml
@@ -2,7 +2,8 @@
 
 ############################# Filbeat ######################################
 filebeat:
-  files:
+  # List of prospectors to fetch data
+  prospectors:
     -
       # Paths that should be crawled and fetched
       paths:

--- a/harvester/harvester.go
+++ b/harvester/harvester.go
@@ -8,7 +8,7 @@ import (
 
 type Harvester struct {
 	Path        string /* the file path to harvest */
-	FileConfig  config.FileConfig
+	ProspectorConfig  config.ProspectorConfig
 	Offset      int64
 	FinishChan  chan int64
 	SpoolerChan chan *input.FileEvent

--- a/harvester/log.go
+++ b/harvester/log.go
@@ -61,7 +61,7 @@ func (h *Harvester) Harvest() {
 			Offset:   h.Offset,
 			Line:     line,
 			Text:     text,
-			Fields:   &h.FileConfig.Fields,
+			Fields:   &h.ProspectorConfig.Fields,
 			Fileinfo: &info,
 		}
 		h.Offset += int64(bytesread)
@@ -218,15 +218,15 @@ func (h *Harvester) handleReadlineError(lastTimeRead time.Time, err error) error
 		// Check to see if the file was truncated
 		info, _ := h.file.Stat()
 
-		if h.FileConfig.IgnoreOlder != "" {
-			logp.Debug("harvester", "Ignore Unmodified After: %s", h.FileConfig.IgnoreOlder)
+		if h.ProspectorConfig.IgnoreOlder != "" {
+			logp.Debug("harvester", "Ignore Unmodified After: %s", h.ProspectorConfig.IgnoreOlder)
 		}
 
 		if info.Size() < h.Offset {
 			logp.Debug("harvester", "File truncated, seeking to beginning: %s", h.Path)
 			h.file.Seek(0, os.SEEK_SET)
 			h.Offset = 0
-		} else if age := time.Since(lastTimeRead); age > h.FileConfig.IgnoreOlderDuration {
+		} else if age := time.Since(lastTimeRead); age > h.ProspectorConfig.IgnoreOlderDuration {
 			// if lastTimeRead was more than ignore older and ignore older is set, this file is probably dead. Stop watching it.
 			logp.Debug("harvester", "Stopping harvest of ", h.Path, "last change was: ", age)
 			return err

--- a/tests/files/config.yml
+++ b/tests/files/config.yml
@@ -1,5 +1,5 @@
 filebeat:
-  files:
+  prospectors:
     -
       # Paths that should be crawled and fetched
       paths:

--- a/tests/files/config2.yml
+++ b/tests/files/config2.yml
@@ -1,5 +1,5 @@
 filebeat:
-  files:
+  prospectors:
     -
       paths:
         - /var/log/*.log

--- a/tests/integration/config/filebeat.yml.j2
+++ b/tests/integration/config/filebeat.yml.j2
@@ -1,6 +1,6 @@
 ############################# Filbeat ######################################
 filebeat:
-  files:
+  prospectors:
     -
       # Paths that should be crawled and fetched
       paths:


### PR DESCRIPTION
With moving also more options to the "files" config option which are actually prospector config options, this config option was renamed to make it more obvious and logic between code and config file.