### PR TITLE
Add OSX build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+os:
+  - linux
+  - osx
+
 go:
   - 1.5
 


### PR DESCRIPTION
The file comparison parts are different between linux and bsd systems. Unit and Integration tests should be run on both platforms. If possible, running tests under windows should be added with http://www.appveyor.com/