### PR TITLE
Fixes for the tests under Windows

### DIFF
--- a/beat/registrar.go
+++ b/beat/registrar.go
@@ -72,10 +72,11 @@ func (r *Registrar) writeRegistry(state map[string]*FileState) error {
 		logp.Err("Failed to create tempfile (%s) for writing: %s", tempfile, e)
 		return e
 	}
-	defer file.Close()
 
 	encoder := json.NewEncoder(file)
 	encoder.Encode(state)
+
+	file.Close()
 
 	return SafeFileRotate(r.registryFile, tempfile)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,10 +1,11 @@
 package config
 
 import (
-	"github.com/elastic/libbeat/cfgfile"
-	"github.com/stretchr/testify/assert"
 	"path/filepath"
 	"testing"
+
+	"github.com/elastic/libbeat/cfgfile"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestReadConfig(t *testing.T) {
@@ -81,8 +82,8 @@ func TestGetConfigFiles_Dir(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(files))
 
-	assert.Equal(t, absPath+"/config.yml", files[0])
-	assert.Equal(t, absPath+"/config2.yml", files[1])
+	assert.Equal(t, filepath.Join(absPath, "/config.yml"), files[0])
+	assert.Equal(t, filepath.Join(absPath, "/config2.yml"), files[1])
 }
 
 func TestGetConfigFiles_EmptyDir(t *testing.T) {

--- a/tests/integration/config/filebeat.yml.j2
+++ b/tests/integration/config/filebeat.yml.j2
@@ -4,7 +4,7 @@ filebeat:
     -
       # Paths that should be crawled and fetched
       paths:
-        - "{{ path }}"
+        - {{ path }}
       # Type of the files. Annotated in every documented
       input: log
       scanfrequency: 1s
@@ -79,7 +79,7 @@ output:
   # number of files: maximum number of files in path
   file:
     enabled: true
-    path: "{{ output_file_path|default(fb.working_dir + "/output") }}"
+    path: {{ output_file_path|default(fb.working_dir + "/output") }}
     filename: "{{ output_file_filename|default("filebeat") }}"
     rotate_every_kb: 1000
     #number_of_files: 7

--- a/tests/integration/test_prospector.py
+++ b/tests/integration/test_prospector.py
@@ -42,7 +42,7 @@ class Test(TestCase):
 
         proc.kill_and_wait()
 
-    def test_not_ingore_old_files(self):
+    def test_not_ignore_old_files(self):
         """
         Should not ignore files there were modified more recent than
         the ignoreOlder settings.


### PR DESCRIPTION
* Don't use quotes in the template because that causes
  yaml to miss-interpret the backslashes
* Use filepath.Join where necessary
* Close the registry file before rotating it. Simplified the rotation logic.
* Expect different values in the .filebeat: another length and no inode/device.