### PR TITLE
Fix SafeFileRotate on Windows

### DIFF
--- a/crawler/registrar.go
+++ b/crawler/registrar.go
@@ -75,7 +75,7 @@ func (r *Registrar) WriteState(input chan []*FileEvent) {
 
 		if e := r.writeRegistry(); e != nil {
 			// REVU: but we should panic, or something, right?
-			logp.Warn("WARNING: (continuing) update of registry returned error: %s", e)
+			logp.Err("Update of registry returned error: %v. Continuing..", e)
 		}
 	}
 	logp.Debug("registrar", "Ending Registrar")

--- a/input/filecompare.go
+++ b/input/filecompare.go
@@ -3,14 +3,15 @@
 package input
 
 import (
-	"github.com/elastic/libbeat/logp"
 	"os"
+
+	"github.com/elastic/libbeat/logp"
 )
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
 func SafeFileRotate(path, tempfile string) error {
 	if e := os.Rename(tempfile, path); e != nil {
-		logp.Info("Registry rotate error: rename of %s to %s - Error: %s", tempfile, path, e)
+		logp.Err("Rotate error: %s", e)
 		return e
 	}
 	return nil

--- a/input/filecompare_test.go
+++ b/input/filecompare_test.go
@@ -1,0 +1,66 @@
+package input
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeFileRotateExistingFile(t *testing.T) {
+
+	tempdir, err := ioutil.TempDir("", "")
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.RemoveAll(tempdir))
+	}()
+
+	// create an existing .filebeat file
+	err = ioutil.WriteFile(filepath.Join(tempdir, ".filebeat"),
+		[]byte("existing filebeat"), 0x777)
+	assert.NoError(t, err)
+
+	// create a new .filebeat.new file
+	err = ioutil.WriteFile(filepath.Join(tempdir, ".filebeat.new"),
+		[]byte("new filebeat"), 0x777)
+	assert.NoError(t, err)
+
+	// rotate .filebeat.new into .filebeat
+	err = SafeFileRotate(filepath.Join(tempdir, ".filebeat"),
+		filepath.Join(tempdir, ".filebeat.new"))
+	assert.NoError(t, err)
+
+	contents, err := ioutil.ReadFile(filepath.Join(tempdir, ".filebeat"))
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("new filebeat"), contents)
+
+	// do it again to make sure we deal with deleting the old file
+
+	err = ioutil.WriteFile(filepath.Join(tempdir, ".filebeat.new"),
+		[]byte("new filebeat 1"), 0x777)
+	assert.NoError(t, err)
+
+	err = SafeFileRotate(filepath.Join(tempdir, ".filebeat"),
+		filepath.Join(tempdir, ".filebeat.new"))
+	assert.NoError(t, err)
+
+	contents, err = ioutil.ReadFile(filepath.Join(tempdir, ".filebeat"))
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("new filebeat 1"), contents)
+
+	// and again for good measure
+
+	err = ioutil.WriteFile(filepath.Join(tempdir, ".filebeat.new"),
+		[]byte("new filebeat 2"), 0x777)
+	assert.NoError(t, err)
+
+	err = SafeFileRotate(filepath.Join(tempdir, ".filebeat"),
+		filepath.Join(tempdir, ".filebeat.new"))
+	assert.NoError(t, err)
+
+	contents, err = ioutil.ReadFile(filepath.Join(tempdir, ".filebeat"))
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("new filebeat 2"), contents)
+}


### PR DESCRIPTION
This whole thing is caused by the fact that os.Rename fails on
Windows if the destination exists. This was somehow taken into
account by the existing code by moving .filebeat to filebeat.old
first, but it didn't quite work because:

1. .filebeat might not exist
2. .filebeat.old might exist