### PR TITLE
Install config target and default template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ filebeat: $(GOFILES)
 	go get github.com/tools/godep
 	$(GODEP) go build
 
+
 .PHONY: check
 check:
 	# This should be modified so it throws an error on the build system in case the output is not empty
@@ -64,3 +65,14 @@ crosscompile: $(GOFILES)
 	go get github.com/tools/godep
 	mkdir -p bin
 	source crosscompile.bash; OUT='bin' go-build-all
+
+# This is called by the beats-packer to obtain the configuration file and
+# default template
+.PHONY: install_cfg
+install_cfg:
+	cp etc/filebeat.yml $(PREFIX)/filebeat-linux.yml
+	cp etc/filebeat.template.json $(PREFIX)/filebeat.template.json
+	# darwin
+	cp etc/filebeat.yml $(PREFIX)/filebeat-darwin.yml
+	# win
+	cp etc/filebeat.yml $(PREFIX)/filebeat-win.yml

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ crosscompile: $(GOFILES)
 
 # This is called by the beats-packer to obtain the configuration file and
 # default template
-.PHONY: install_cfg
-install_cfg:
+.PHONY: install-cfg
+install-cfg:
 	cp etc/filebeat.yml $(PREFIX)/filebeat-linux.yml
 	cp etc/filebeat.template.json $(PREFIX)/filebeat.template.json
 	# darwin

--- a/etc/filebeat.template.json
+++ b/etc/filebeat.template.json
@@ -1,0 +1,21 @@
+{
+  "mappings": {
+    "_default_": {
+      "_all": {
+        "enabled": true,
+        "norms": {
+          "enabled": false
+        }
+      },
+      "properties": {
+        "timestamp": {
+          "type": "date"
+        }
+      }
+    }
+  },
+  "settings": {
+    "index.refresh_interval": "5s"
+  },
+  "template": "filebeat-*"
+}


### PR DESCRIPTION
This adds the `install_cfg` Makefile target which is required by the beats-packer. Besides the configuration file, this is supposed to also install the default ES mapping template. I added a very basic template file, a more complete template should be worked out separately.