### PR TITLE
lumberjack: field compat for logstash codec

### DIFF
--- a/beat/filebeat.go
+++ b/beat/filebeat.go
@@ -138,7 +138,7 @@ func Publish(beat *beat.Beat, fb *Filebeat) {
 				"timestamp": common.Time(time.Now()),
 				"source":    event.Source,
 				"offset":    event.Offset,
-				"line":      event.Line,
+				"message":   event.Line,
 				"text":      event.Text,
 				"fields":    event.Fields,
 				"fileinfo":  event.Fileinfo,


### PR DESCRIPTION
Rename “line” field to “message” to improve compatibility with logstash-forwarder when message is send to lumberjack or pushed into ES directly.