### PR TITLE
Implements ReadOpen to make read only files available on windows

### DIFF
--- a/harvester/log.go
+++ b/harvester/log.go
@@ -105,7 +105,7 @@ func (h *Harvester) open() *os.File {
 
 	for {
 		var err error
-		h.file, err = os.Open(h.Path)
+		h.file, err = input.ReadOpen(h.Path)
 
 		if err != nil {
 			// TODO: This is currently end endless retry, should be set to a max?

--- a/input/file_other.go
+++ b/input/file_other.go
@@ -41,3 +41,12 @@ func SafeFileRotate(path, tempfile string) error {
 	}
 	return nil
 }
+
+// ReadOpen opens a file for reading only
+func ReadOpen(path string) (*os.File, error) {
+
+	flag := os.O_RDONLY
+	var perm os.FileMode = 0
+
+	return os.OpenFile(path, flag, perm)
+}

--- a/input/file_windows.go
+++ b/input/file_windows.go
@@ -1,8 +1,10 @@
 package input
 
 import (
+	"fmt"
 	"os"
 	"reflect"
+	"syscall"
 
 	"github.com/elastic/libbeat/logp"
 )
@@ -66,4 +68,43 @@ func SafeFileRotate(path, tempfile string) error {
 		return e
 	}
 	return nil
+}
+
+// ReadOpen opens a file for reading only
+// As Windows blocks deleting a file when its open, some special params are passed here.
+func ReadOpen(path string) (*os.File, error) {
+
+	// Set all write flags
+	// This indirectly calls syscall_windows::Open method https://github.com/golang/go/blob/7ebcf5eac7047b1eef2443eda1786672b5c70f51/src/syscall/syscall_windows.go#L251
+	// As FILE_SHARE_DELETE cannot be passed to Open, os.CreateFile must be implemented directly
+
+	// This is mostly the code from syscall_windows::Open. Only difference is passing the Delete flag
+	// TODO: Open pull request to Golang so also Delete flag can be set
+	if len(path) == 0 {
+		return nil, fmt.Errorf("File '%s' not found. Error: %v", syscall.ERROR_FILE_NOT_FOUND)
+	}
+
+	pathp, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, fmt.Errorf("Error converting to UTF16: %v", err)
+	}
+
+	var access uint32
+	access = syscall.GENERIC_READ | syscall.GENERIC_WRITE
+
+	sharemode := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE)
+
+	var sa *syscall.SecurityAttributes
+
+	var createmode uint32
+
+	createmode = syscall.OPEN_EXISTING
+
+	handle, err := syscall.CreateFile(pathp, access, sharemode, sa, createmode, syscall.FILE_ATTRIBUTE_NORMAL, 0)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error creating file '%s': %v", pathp, err)
+	}
+
+	return os.NewFile(uintptr(handle), path), nil
 }

--- a/tests/system/test_crawler.py
+++ b/tests/system/test_crawler.py
@@ -86,7 +86,6 @@ class Test(TestCase):
         # Check that output file has the same number of lines as the log file
         assert iterations == len(output)
 
-    @unittest.skipIf(os.name == "nt", "Watching log file currently not supported on Windows")
     def test_file_renaming(self):
         """
         Makes sure that when a file is renamed, the content is not read again.
@@ -141,7 +140,6 @@ class Test(TestCase):
         # Make sure all 11 lines were read
         assert len(output) == 11
 
-    @unittest.skipIf(os.name == "nt", "Watching log file currently not supported on Windows")
     def test_file_disappear(self):
         """
         Checks that filebeat keeps running in case a log files is deleted


### PR DESCRIPTION
The problem on windows is that files which are already opened for reading cannot be read by and other process by default. This implements special flags to make the file available for reading on Windows.

In the future this should be extended also for files which have to be written to and moved into libbeat. See also: https://github.com/elastic/filebeat/pull/56