### PR TITLE
Custom registry file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,14 @@ crosscompile: $(GOFILES)
 # default template
 .PHONY: install-cfg
 install-cfg:
-	cp etc/filebeat.yml $(PREFIX)/filebeat-linux.yml
 	cp etc/filebeat.template.json $(PREFIX)/filebeat.template.json
+	# linux
+	cp etc/filebeat.yml $(PREFIX)/filebeat-linux.yml
+	sed -i 's$#registryFile: .filebeat$registryFile: /var/lib/filebeat/registry' $(PREFIX)/filebeat-linux.yml
+	# binary
+	cp etc/filebeat.yml $(PREFIX)/filebeat-binary.yml
 	# darwin
 	cp etc/filebeat.yml $(PREFIX)/filebeat-darwin.yml
 	# win
 	cp etc/filebeat.yml $(PREFIX)/filebeat-win.yml
+	sed -i 's$#registryFile: .filebeat$registryFile: C:\ProgramData\filebeat\registry' $(PREFIX)/filebeat-windows.yml

--- a/beat/filebeat.go
+++ b/beat/filebeat.go
@@ -57,11 +57,17 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 		os.Exit(1)
 	}()
 
+	var err error
+
 	// Init channels
 	fb.publisherChan = make(chan []*FileEvent, 1)
 
 	// Setup registrar to persist state
-	fb.registrar = NewRegistrar(fb.FbConfig.Filebeat.RegistryFile)
+	fb.registrar, err = NewRegistrar(fb.FbConfig.Filebeat.RegistryFile)
+	if err != nil {
+		logp.Err("Could not init registrar: %v", err)
+		return err
+	}
 
 	crawl := &Crawler{
 		Registrar: fb.registrar,
@@ -72,7 +78,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 
 	// Init and Start spooler: Harvesters dump events into the spooler.
 	fb.Spooler = NewSpooler(fb)
-	err := fb.Spooler.Config()
+	err = fb.Spooler.Config()
 
 	if err != nil {
 		logp.Err("Could not init spooler: %v", err)

--- a/tests/system/config/filebeat.yml.j2
+++ b/tests/system/config/filebeat.yml.j2
@@ -13,7 +13,7 @@ filebeat:
   spoolSize:
   idleTimeout: 5s
   tailOnRotate:
-  registryFile: {{ fb.working_dir + '/' }}.filebeat
+  registryFile: {{ fb.working_dir + '/' }}{{ registryFile|default(".filebeat")}}
 
 
 

--- a/tests/system/test_registrar.py
+++ b/tests/system/test_registrar.py
@@ -55,7 +55,6 @@ class Test(TestCase):
         # Check that right source field is inside
         assert data[logFileAbs]['source'] == logFileAbs
 
-
         # Check that no additional info is in the file
         assert len(data) == 1
 
@@ -74,14 +73,11 @@ class Test(TestCase):
 
             # Check that device is set correctly
             device = os.stat(logFileAbs).st_dev
-            assert os.name == "nt" or data[logFileAbs]['FileStateOS']['device'] == device
+            assert os.name == "nt" or \
+                data[logFileAbs]['FileStateOS']['device'] == device
 
             assert len(data[logFileAbs]) == 3
             assert len(data[logFileAbs]['FileStateOS']) == 2
-
-
-
-
 
     def test_registrar_files(self):
         """
@@ -121,3 +117,22 @@ class Test(TestCase):
 
         # Check that 2 files are port of the registrar file
         assert len(data) == 2
+
+    def test_custom_registry_file_location(self):
+        """
+        Check that when a custom registry file is used, the path
+        is created automatically.
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            registryFile="a/b/c/registry",
+        )
+        filebeat = self.start_filebeat()
+        # just need to give it enough time to initialize
+        self.wait_until(
+            lambda: self.log_contains(
+                "Starting Registrar"),
+            max_timeout=3)
+        filebeat.kill_and_wait()
+
+        assert os.path.isfile(os.path.join(self.working_dir, "a/b/c/registry"))

--- a/tests/system/test_registrar.py
+++ b/tests/system/test_registrar.py
@@ -127,12 +127,15 @@ class Test(TestCase):
             path=os.path.abspath(self.working_dir) + "/log/*",
             registryFile="a/b/c/registry",
         )
+        os.mkdir(self.working_dir + "/log/")
+        testfile = self.working_dir + "/log/test.log"
+        with open(testfile, 'w') as f:
+            f.write("hello world\n")
         filebeat = self.start_filebeat()
-        # just need to give it enough time to initialize
         self.wait_until(
             lambda: self.log_contains(
-                "Starting Registrar"),
-            max_timeout=3)
+                "Registrar: processing 1 events"),
+            max_timeout=15)
         filebeat.kill_and_wait()
 
         assert os.path.isfile(os.path.join(self.working_dir, "a/b/c/registry"))


### PR DESCRIPTION
Modify the default configuration file to place the registry file on a different location depending on the platform, as requested by #82:

* On windows, `c:\ProgramData\Filebeat\registry`
* On Debian/Redhat systems if installed from pacakge, `/var/lib/filebeat/registry`.
* When downloading a tar/tgz/zip leave the default of using the current working dir
