### PR TITLE
Experiment on the flaky registrar tests.

### DIFF
--- a/tests/system/test_registrar.py
+++ b/tests/system/test_registrar.py
@@ -34,6 +34,13 @@ class Test(TestCase):
             lambda: self.log_contains(
                 "Registrar: processing 5 events"),
             max_timeout=15)
+
+        # wait until the registry file exist. Needed to avoid a race between
+        # the logging and actual writing the file. Seems to happen on Windows.
+        self.wait_until(
+            lambda: os.path.isfile(os.path.join(self.working_dir,
+                                                ".filebeat")),
+            max_timeout=1)
         filebeat.kill_and_wait()
 
         # Check that file exist
@@ -110,6 +117,12 @@ class Test(TestCase):
             lambda: self.log_contains(
                 "Registrar: processing 10 events"),
             max_timeout=15)
+        # wait until the registry file exist. Needed to avoid a race between
+        # the logging and actual writing the file. Seems to happen on Windows.
+        self.wait_until(
+            lambda: os.path.isfile(os.path.join(self.working_dir,
+                                                ".filebeat")),
+            max_timeout=1)
         filebeat.kill_and_wait()
 
         # Check that file exist
@@ -136,6 +149,13 @@ class Test(TestCase):
             lambda: self.log_contains(
                 "Registrar: processing 1 events"),
             max_timeout=15)
+        # wait until the registry file exist. Needed to avoid a race between
+        # the logging and actual writing the file. Seems to happen on Windows.
+        self.wait_until(
+            lambda: os.path.isfile(os.path.join(self.working_dir,
+                                                "a/b/c/registry")),
+
+            max_timeout=1)
         filebeat.kill_and_wait()
 
         assert os.path.isfile(os.path.join(self.working_dir, "a/b/c/registry"))


### PR DESCRIPTION
I cannot get the Windows flaky tests to fail on my Windows
machine. There's a fairly theoretical race between the log file
being written and the kill command (that doesn't do any cleanup
on windows), so adding a condition to only do the kill after the
file has reached the FS.

Even if not successful, this should give us further info on what's
wrong.