### PR TITLE
Fix windows issue by making special check for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file based on the
 [Keep a Changelog](http://keepachangelog.com/) Standard.
 
 
-## [Unreleased](https://github.com/elastic/filebeat/compare/13678f4...HEAD)
+## [Unreleased](https://github.com/elastic/filebeat/compare/1.0.0-beta4...HEAD)
 
 This is the first filebeat release. As of this no changelog is provided for the first release.
 All documentation about Filebeat can be found here.
@@ -23,9 +23,15 @@ All documentation about Filebeat can be found here.
 
 ### Added
 - Rename the timestamp field with @timestamp #168
+- Introduction of backoff, backoff_factor, max_backoff, partial_line_waiting, force_close_windows_files
+  config variables to make crawling more configurable.
 
 ### Improvements
 - All Godeps dependencies were updated to master on 2015-10-21 [#122]
 - Set default value for ignore_older config to 10 minutes. #164
 
 ### Deprecated
+
+
+## [1.0.0-beta4](https://github.com/elastic/topbeat/compare/13678f4...1.0.0-beta4) - 2015-10-22
+This was the first release of Filebeat.

--- a/config/config.go
+++ b/config/config.go
@@ -12,14 +12,19 @@ import (
 
 // Defaults for config variables which are not set
 const (
-	DefaultRegistryFile                      = ".filebeat"
-	DefaultIgnoreOlderDuration time.Duration = 10 * time.Minute
-	DefaultScanFrequency       time.Duration = 10 * time.Second
-	DefaultSpoolSize           uint64        = 1024
-	DefaultIdleTimeout         time.Duration = 5 * time.Second
-	DefaultHarvesterBufferSize int           = 16 << 10 // 16384
-	DefaultDocumentType                      = "log"
-	DefaultTailFiles                         = false
+	DefaultRegistryFile                         = ".filebeat"
+	DefaultIgnoreOlderDuration    time.Duration = 10 * time.Minute
+	DefaultScanFrequency          time.Duration = 10 * time.Second
+	DefaultSpoolSize              uint64        = 1024
+	DefaultIdleTimeout            time.Duration = 5 * time.Second
+	DefaultHarvesterBufferSize    int           = 16 << 10 // 16384
+	DefaultDocumentType                         = "log"
+	DefaultTailFiles                            = false
+	DefaultBackoff                              = 1 * time.Second
+	DefaultBackoffFactor                        = 2
+	DefaultMaxBackoff                           = 10 * time.Second
+	DefaultPartialLineWaiting                   = 5 * time.Second
+	DefaultForceCloseWindowsFiles               = false
 )
 
 type Config struct {
@@ -46,12 +51,20 @@ type ProspectorConfig struct {
 }
 
 type HarvesterConfig struct {
-	InputType    string `yaml:"input_type"`
-	Fields       map[string]string
-	BufferSize   int    `yaml:"harvester_buffer_size"`
-	TailFiles    bool   `yaml:"tail_files"`
-	Encoding     string `yaml:"encoding"`
-	DocumentType string `yaml:"document_type"`
+	InputType                  string `yaml:"input_type"`
+	Fields                     map[string]string
+	BufferSize                 int    `yaml:"harvester_buffer_size"`
+	TailFiles                  bool   `yaml:"tail_files"`
+	Encoding                   string `yaml:"encoding"`
+	DocumentType               string `yaml:"document_type"`
+	Backoff                    string `yaml:"backoff"`
+	BackoffDuration            time.Duration
+	BackoffFactor              int    `yaml:"backoff_factor"`
+	MaxBackoff                 string `yaml:"max_backoff"`
+	MaxBackoffDuration         time.Duration
+	PartialLineWaiting         string `yaml:"partial_line_wating"`
+	PartialLineWaitingDuration time.Duration
+	ForceCloseWindowsFiles     bool `yaml:"force_close_windows_files"`
 }
 
 // getConfigFiles returns list of config files.

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -15,7 +15,7 @@ import (
  Crawler: Filebeat has one crawler. The crawler is the single point of control
  	and stores the state. The state is written through the registrar
  Prospector: For every FileConfig the crawler starts a prospector
- Harvestor: For every file found inside the FileConfig, the Prospector starts a Harvestor
+ Harvester: For every file found inside the FileConfig, the Prospector starts a Harvester
  		The harvester send their events to the spooler
  		The spooler sends the event to the publisher
  		The publisher writes the state down with the registrar

--- a/crawler/prospector_test.go
+++ b/crawler/prospector_test.go
@@ -70,6 +70,11 @@ func TestProspectorInitNotSet(t *testing.T) {
 	assert.Equal(t, config.DefaultScanFrequency, prospector.ProspectorConfig.ScanFrequencyDuration)
 	assert.Equal(t, config.DefaultHarvesterBufferSize, prospector.ProspectorConfig.Harvester.BufferSize)
 	assert.Equal(t, config.DefaultTailFiles, prospector.ProspectorConfig.Harvester.TailFiles)
+	assert.Equal(t, config.DefaultBackoff, prospector.ProspectorConfig.Harvester.BackoffDuration)
+	assert.Equal(t, config.DefaultBackoffFactor, prospector.ProspectorConfig.Harvester.BackoffFactor)
+	assert.Equal(t, config.DefaultMaxBackoff, prospector.ProspectorConfig.Harvester.MaxBackoffDuration)
+	assert.Equal(t, config.DefaultPartialLineWaiting, prospector.ProspectorConfig.Harvester.PartialLineWaitingDuration)
+	assert.Equal(t, config.DefaultForceCloseWindowsFiles, prospector.ProspectorConfig.Harvester.ForceCloseWindowsFiles)
 }
 
 func TestProspectorInitScanFrequency0(t *testing.T) {

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -142,6 +142,52 @@ Setting tail_files to true means filebeat starts readding new files at the end
 instead of the beginning. If this is used in combination with log rotation
 this can mean that the first entries of a new file are skipped.
 
+===== backoff
+
+Backoff values define how agressively filebeat crawls new files for updates
+The default values can be used in most cases. Backoff defines how long it is waited
+to check a file again after EOF is reached. Default is 1s which means the file
+is checked every second if new lines were added. This leads to a near real time crawling.
+Every time a new line appears, backoff is reset to the initial value.
+Default: 1s
+
+===== max_backoff
+
+Max backoff defines what the maximum waiting time is. After having backed off multiple times
+from checking the files, the waiting time will never exceed max_backoff idenependent of the
+backoff factor. Having it set to 10s means in the worst case a new line can be added to a log
+file after having backed off multiple times, it takes a maximum of 10s to read the new line.
+Default: 10s
+
+===== backoff_factor
+
+The backoff factor defines how fast the waiting time is increased. The bigger the backoff factor,
+the faster the max_backoff value is reached. The backoff increments exponential.
+The minimal value allowed is 1. If this value is set to 1 it means backoff algorithm is disabled
+and the backoff value is used for waiting for new lines.
+The backoff value will be multiplied each time with the backoff_factor until max_backoff is reached.
+Default: 2
+
+===== partial_line_waiting
+
+Defines the time on how long the harvester will wait for a line to be completed.
+Sometimes a lines it not completely written when checked by filebeat. Filebeat
+will wait for the time defined below so the system can complete the line.
+In case the line is not completed in this time, the line will be skipped.
+Default: 5s
+
+===== force_close_windows_files
+
+This option closes a file on windows, as soon as the file name changes.
+This config option is windows only. Filebeat keeps the files it's reading open. This can cause
+issues when the file is removed, as the file will not be fully removed until also filebeat closes
+the reading. Filebeat closes the file handler after ignore_older. During this time no new file with the
+same name can be created. Turning this feature on the other hand can lead to loss of data
+on rotate files. It can happen that after file rotation the beginning of the new
+file is skipped, as the reading starts at the end. We recommend to leave this option on false
+but lower the ignore_older value to release files faster.
+Default: false
+
 ===== spool_size
 
 Event count spool threshold - forces network flush if exceeded.

--- a/etc/filebeat.yml
+++ b/etc/filebeat.yml
@@ -58,6 +58,39 @@ filebeat:
       # this can mean that the first entries of a new file are skipped.
       #tail_files: false
 
+      # Backoff values define how agressively filebeat crawls new files for updates
+      # The default values can be used in most cases. Backoff defines how long it is waited
+      # to check a file again after EOF is reached. Default is 1s which means the file
+      # is checked every second if new lines were added. This leads to a near real time crawling.
+      # Every time a new line appears, backoff is reset to the initial value.
+      #backoff: 1s
+
+      # Max backoff defines what the maximum backoff time is. After having backed off multiple times
+      # from checking the files, the waiting time will never exceed max_backoff idenependent of the
+      # backoff factor. Having it set to 10s means in the worst case a new line can be added to a log
+      # file after having backed off multiple times, it takes a maximum of 10s to read the new line
+      #max_backoff: 10s
+
+      # The backoff factor defines how fast the algorithm backs off. The bigger the backoff factor,
+      # the faster the max_backoff value is reached. If this value is set to 1, no backoff will happen.
+      # The backoff value will be multiplied each time with the backoff_factor until max_backoff is reached
+      #backoff_factor: 2
+
+      # Defines the time on how long the harvester will wait for a line to be completed.
+      # Sometimes a lines it not completely written when checked by filebeat. Filebeat
+      # will wait for the time defined below so the system can complete the line.
+      # In case the line is not completed in this time, the line will be skipped.
+      #partial_line_waiting: 5s
+
+      # This option closes a file on windows, as soon as the file name changes.
+      # This config option is windows only. Filebeat keeps the files it's reading open. This can cause
+      # issues when the file is removed, as the file will not be fully removed until also filebeat closes
+      # the reading. Filebeat closes the file handler after ignore_older. During this time no new file with the
+      # same name can be created. Turning this feature on can on the other hand lead to loss of data
+      # on rotate files as rotate files are not followed. We recommend to leave this option on false
+      # but lower the ignore_older value to release files faster.
+      #force_close_windows_files: false
+
     #-
     #  paths:
     #    - /var/log/apache/*.log

--- a/harvester/log.go
+++ b/harvester/log.go
@@ -3,9 +3,11 @@ package harvester
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/elastic/filebeat/config"
@@ -36,54 +38,107 @@ func NewHarvester(
 	return h, nil
 }
 
-// Log harvester reads files line by line and sends events to logstash
-// Multiline log support is required
-
+// Log harvester reads files line by line and sends events to the defined output
 func (h *Harvester) Harvest() {
-	h.open()
-	info, e := h.file.Stat()
 
-	if e != nil {
-		panic(fmt.Sprintf("Harvest: unexpected error: %s", e.Error()))
+	err := h.open()
+
+	// Make sure file is closed as soon as harvester exits
+	defer h.file.Close()
+
+	if err != nil {
+		logp.Err("Stop Harvesting. Unexpected Error: %s", err)
+		return
 	}
 
-	// File is closed as soon as harvester stops
-	defer h.file.Close()
+	info, err := h.file.Stat()
+	if err != nil {
+		logp.Err("Stop Harvesting. Unexpected Error: %s", err)
+		return
+	}
 
 	// On completion, push offset so we can continue where we left off if we relaunch on the same file
 	defer func() {
 		h.FinishChan <- h.Offset
 	}()
 
-	var line uint64 = 0 // Ask registrar about the line number
+	var line uint64 = 0
 
+	// Load last offset from registrar
 	h.initOffset()
+
 	in := h.encoding(h.file)
+
 	reader := bufio.NewReaderSize(in, h.Config.BufferSize)
 	buffer := bytes.NewBuffer(nil)
+	hConfig := h.ProspectorConfig.Harvester
 
-	var readTimeout = 10 * time.Second
+	// It waits a maximum of 5 seconds for a partial line to be update
+	partialLineWaiting := hConfig.PartialLineWaitingDuration
+
+	// Current backoff when reaching EOF
+	backoff := hConfig.BackoffDuration
+
+	// Maximum backoff time. Backoff will not exceed this value
+	maxBackoff := hConfig.MaxBackoffDuration
+
+	// Factor to increase backoff every time
+	backoffFactor := time.Duration(hConfig.BackoffFactor)
+
+	// Windows setting
+	forceCloseWindowsFiles := hConfig.ForceCloseWindowsFiles
+
 	lastReadTime := time.Now()
-	for {
 
-		text, bytesread, err := h.readLine(reader, buffer, readTimeout)
+	for {
+		text, bytesRead, err := readLine(reader, buffer, partialLineWaiting)
 
 		if err != nil {
+			// End of file
+			if err == io.EOF {
+
+				// On windows, check if the file name exists (see #93)
+				if forceCloseWindowsFiles && runtime.GOOS == "windows" {
+					_, statErr := os.Stat(h.file.Name())
+					if statErr != nil {
+						logp.Err("Unexpected windows specific error reading from %s; error: %s", h.Path, statErr)
+						// Return directly on windows -> file is closing
+						return
+					}
+				}
+
+				// Wait before trying to read file which reached EOF again
+				time.Sleep(backoff)
+
+				// Increment backoff up to maxBackoff
+				if backoff < maxBackoff {
+					backoff = backoff * backoffFactor
+					if backoff > maxBackoff {
+						backoff = maxBackoff
+					}
+				}
+			}
+
+			// In case of err = io.EOF returns nil
 			err = h.handleReadlineError(lastReadTime, err)
 
 			if err != nil {
+				logp.Err("File reading error. Stopping harvester. Error: %s", err)
 				return
-			} else {
-				// EOF reached, reset encoding
-				in = h.encoding(h.file)
-				reader = bufio.NewReaderSize(in, h.Config.BufferSize)
-				continue
 			}
+
+			// EOF reached
+			// Encoding and reader are reinitialised here as other encoder stops reading. See #182
+			in = h.encoding(h.file)
+			reader = bufio.NewReaderSize(in, h.Config.BufferSize)
+			continue
 		}
 
 		lastReadTime = time.Now()
-
+		backoff = hConfig.BackoffDuration
 		line++
+
+		// Sends text to spooler
 		event := &input.FileEvent{
 			ReadTime:     lastReadTime,
 			Source:       &h.Path,
@@ -95,9 +150,9 @@ func (h *Harvester) Harvest() {
 			Fields:       &h.Config.Fields,
 			Fileinfo:     &info,
 		}
-		h.Offset += int64(bytesread)
 
-		h.SpoolerChan <- event // ship the new event downstream
+		h.Offset += int64(bytesRead) // Update offset
+		h.SpoolerChan <- event       // ship the new event downstream
 	}
 }
 
@@ -128,11 +183,12 @@ func (h *Harvester) setFileOffset() {
 	}
 }
 
-func (h *Harvester) open() *os.File {
+// open does open the file given under h.Path and assigns the file handler to h.file
+func (h *Harvester) open() error {
 	// Special handling that "-" means to read from standard input
 	if h.Path == "-" {
 		h.file = os.Stdin
-		return h.file
+		return nil
 	}
 
 	for {
@@ -155,63 +211,58 @@ func (h *Harvester) open() *os.File {
 
 	// Check we are not following a rabbit hole (symlinks, etc.)
 	if !file.IsRegularFile() {
-		// TODO: This should be replaced by a normal error
-		panic(fmt.Errorf("Harvester file error"))
+		return errors.New("Given file is not a regular file.")
 	}
 
 	h.setFileOffset()
 
-	return h.file
+	return nil
 }
 
-// TODO: It seems like this function does not depend at all on harvester
-// To could potentialy be improved / replaced by https://github.com/elastic/libbeat/tree/master/common/streambuf
-func (h *Harvester) readLine(reader *bufio.Reader, buffer *bytes.Buffer, eofTimeout time.Duration) (*string, int, error) {
-	// TODO: Read line should be improved in a way so it can also read multi lines or even full files when required. See "type" in config file
+// handleReadlineError handles error which are raised during reading file.
+//
+// If error is EOF, it will check for:
+// * File truncated
+// * Older then ignore_older
+// * General file error
+//
+// If none of the above cases match, no error will be returned and file is kept open
+//
+// In case of a general error, the error itself is returned
+func (h *Harvester) handleReadlineError(lastTimeRead time.Time, err error) error {
 
-	isPartial := true
-	startTime := time.Now()
+	if err == io.EOF {
+		// Refetch fileinfo to check if the file was truncated or disappeared
+		info, statErr := h.file.Stat()
 
-	for {
-		segment, err := reader.ReadBytes('\n')
-
-		if segment != nil && len(segment) > 0 {
-			if isLine(segment) {
-				isPartial = false
-			}
-
-			// TODO(sissel): if buffer exceeds a certain length, maybe report an error condition? chop it?
-			buffer.Write(segment)
+		// This could happen if the file was removed / rotate after reading and before calling the stat function
+		if statErr != nil {
+			logp.Err("Unexpected error reading from %s; error: %s", h.Path, statErr)
+			return statErr
 		}
 
-		if err != nil {
-			if err == io.EOF && isPartial {
-				time.Sleep(1 * time.Second) // TODO(sissel): Implement backoff
-
-				// Give up waiting for data after a certain amount of time.
-				// If we time out, return the error (eof)
-				if time.Since(startTime) >= eofTimeout {
-					return nil, 0, err
-				}
-				continue
-			} else {
-				logp.Err("Harvester.readLine: %s", err.Error())
-				return nil, 0, err // TODO(sissel): don't do this?
-			}
+		// Check if file was truncated
+		if info.Size() < h.Offset {
+			logp.Debug("harvester", "File was truncated as offset > size. Begin reading file from offset 0: %s", h.Path)
+			h.Offset = 0
+			h.file.Seek(h.Offset, os.SEEK_SET)
+		} else if age := time.Since(lastTimeRead); age > h.ProspectorConfig.IgnoreOlderDuration {
+			// If the file hasn't change for longer the ignore_older, harvester stops and file handle will be closed.
+			logp.Debug("harvester", "Stopping harvesting of file as older then ignore_old: ", h.Path, "Last change was: ", age)
+			return err
 		}
-
-		// If we got a full line, return the whole line without the EOL chars (CRLF or LF)
-		if !isPartial {
-			// Get the str length with the EOL chars (LF or CRLF)
-			bufferSize := buffer.Len()
-			str := new(string)
-			*str = buffer.String()[:bufferSize-lineEndingChars(segment)]
-			// Reset the buffer for the next line
-			buffer.Reset()
-			return str, bufferSize, nil
-		}
+		// Do nothing in case it is just EOF, keep reading the file
+		return nil
+	} else {
+		logp.Err("Unexpected state reading from %s; error: %s", h.Path, err)
+		return err
 	}
 }
+
+func (h *Harvester) Stop() {
+}
+
+/*** Utility Functions ***/
 
 // isLine checks if the given byte array is a line, means has a line ending \n
 func isLine(line []byte) bool {
@@ -242,36 +293,58 @@ func lineEndingChars(line []byte) int {
 	return 0
 }
 
-// Handles error during reading file. If EOF and nothing special, exit without errors
-func (h *Harvester) handleReadlineError(lastTimeRead time.Time, err error) error {
-	if err == io.EOF {
-		// timed out waiting for data, got eof.
-		// Check to see if the file was truncated
-		info, statErr := h.file.Stat()
+// readLine reads a full line into buffer and returns it.
+// In case of partial lines, readLine waits for a maximum of 5 seconds for new segments to arrive.
+// This could potentialy be improved / replaced by https://github.com/elastic/libbeat/tree/master/common/streambuf
+func readLine(reader *bufio.Reader, buffer *bytes.Buffer, partialLineWaiting time.Duration) (*string, int, error) {
 
-		// This could happen if the file was removed / rotate after reading and before calling the stat function
-		if statErr != nil {
-			logp.Err("Unexpected error reading from %s; error: %s", h.Path, statErr)
-			return statErr
+	lastSegementTime := time.Now()
+	isPartialLine := true
+
+	for {
+		segment, err := reader.ReadBytes('\n')
+
+		if segment != nil && len(segment) > 0 {
+			if isLine(segment) {
+				isPartialLine = false
+			}
+
+			// Update last segment time as new segment of line arrived
+			lastSegementTime = time.Now()
+			buffer.Write(segment)
 		}
 
-		if h.ProspectorConfig.IgnoreOlder != "" {
-			logp.Debug("harvester", "Ignore Unmodified After: %s", h.ProspectorConfig.IgnoreOlder)
+		if err != nil {
+			// EOF, jump out of the loop
+			if err == io.EOF {
+				return nil, 0, err
+			}
+
+			if isPartialLine {
+				// Wait for a second for the next segments
+				time.Sleep(1 * time.Second)
+
+				// If last segment written is older then partialLineWaiting, partial line is discarded
+				if time.Since(lastSegementTime) >= partialLineWaiting {
+					return nil, 0, err
+				}
+				continue
+			} else {
+				logp.Err("Error reading line: %s", err.Error())
+				return nil, 0, err
+			}
 		}
 
-		if info.Size() < h.Offset {
-			logp.Debug("harvester", "File truncated, seeking to beginning: %s", h.Path)
-			h.file.Seek(0, os.SEEK_SET)
-			h.Offset = 0
-		} else if age := time.Since(lastTimeRead); age > h.ProspectorConfig.IgnoreOlderDuration {
-			// if lastTimeRead was more than ignore older and ignore older is set, this file is probably dead. Stop watching it.
-			// As an error is returned, the harvester will stop and the file is closed
-			logp.Debug("harvester", "Stopping harvest of ", h.Path, "last change was: ", age)
-			return err
+		// If we got a full line, return the whole line without the EOL chars (LF or CRLF)
+		if !isPartialLine {
+			// Get the str length with the EOL chars (LF or CRLF)
+			bufferSize := buffer.Len()
+			str := new(string)
+			// Remove line endings
+			*str = buffer.String()[:bufferSize-lineEndingChars(segment)]
+			// Reset the buffer for the next line
+			buffer.Reset()
+			return str, bufferSize, nil
 		}
-	} else {
-		logp.Err("Unexpected state reading from %s; error: %s", h.Path, err)
-		return err
 	}
-	return nil
 }

--- a/harvester/log.go
+++ b/harvester/log.go
@@ -130,7 +130,7 @@ func (h *Harvester) Harvest() {
 			// EOF reached
 			// Encoding and reader are reinitialised here as other encoder stops reading. See #182
 			in = h.encoding(h.file)
-			reader = bufio.NewReaderSize(in, h.Config.BufferSize)
+			reader.Reset(in)
 			continue
 		}
 

--- a/harvester/log_test.go
+++ b/harvester/log_test.go
@@ -59,21 +59,21 @@ func TestReadLine(t *testing.T) {
 	buffer := new(bytes.Buffer)
 
 	// Read third line
-	text, bytesread, err := h.readLine(reader, buffer, 0)
+	text, bytesread, err := readLine(reader, buffer, 0)
 
 	assert.Equal(t, *text, firstLineString[0:len(firstLineString)-1])
 	assert.Equal(t, bytesread, len(firstLineString))
 	assert.Nil(t, err)
 
 	// read second line
-	text, bytesread, err = h.readLine(reader, buffer, 0)
+	text, bytesread, err = readLine(reader, buffer, 0)
 
 	assert.Equal(t, *text, secondLineString[0:len(secondLineString)-1])
 	assert.Equal(t, bytesread, len(secondLineString))
 	assert.Nil(t, err)
 
 	// Read third line, which doesn't exist
-	text, bytesread, err = h.readLine(reader, buffer, 0)
+	text, bytesread, err = readLine(reader, buffer, 0)
 	assert.Nil(t, text)
 	assert.Equal(t, bytesread, 0)
 	assert.Equal(t, err, io.EOF)

--- a/tests/system/config/filebeat.yml.j2
+++ b/tests/system/config/filebeat.yml.j2
@@ -7,15 +7,18 @@ filebeat:
         - {{ path }}
       # Type of the files. Annotated in every documented
       input: log
-      scan_frequency: 0.5s
+      scan_frequency: 1s
       ignore_older: "{{ignoreOlder}}"
       harvester_buffer_size:
       encoding: {{encoding | default("utf-8") }}
       tail_files: {{tailFiles}}
+      backoff: 1s
+      backoff_factor: 1
+      max_backoff: 1s
+      force_close_windows_files: {{force_close_windows_files}}
   spool_size:
   idle_timeout: 0.5s
   registry_file: {{ fb.working_dir + '/' }}{{ registryFile|default(".filebeat")}}
-
 
 
 ############################# Shipper ############################################

--- a/tests/system/test_crawler.py
+++ b/tests/system/test_crawler.py
@@ -201,15 +201,17 @@ class Test(TestCase):
 
         assert len(output) == 5 + 6
 
-    @unittest.skipIf(os.name == "nt", "Watching log file currently not " +
-                                      "supported on Windows")
     def test_file_disappear_appear(self):
         """
         Checks that filebeat keeps running in case a log files is deleted
+
+        On Windows this tests in addition if the file was closed as it couldn't be found anymore
+        If Windows does not close the file, a new one can't be created.
         """
 
         self.render_config_template(
-            path=os.path.abspath(self.working_dir) + "/log/*"
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            force_close_windows_files="true"
         )
         os.mkdir(self.working_dir + "/log/")
 


### PR DESCRIPTION
See https://github.com/elastic/filebeat/issues/93

Remove skipping tests
Introduce running variable to directly stop after file removal.

* [x] Discuss configuration options
  * What should be configurable?
  * What are the default options?
  * Variables to discuss:
    * backoff
       * maxBackoff
       * backoffFactor
    * partialLineWaitingTime
    * forceCloseFilesWindows
* [x] introduce config variables
* [x] Update CHANGELOG.md