### PR TITLE
Fix #149: Remove espacing of path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,4 +83,4 @@ install-cfg:
 	cp etc/filebeat.yml $(PREFIX)/filebeat-darwin.yml
 	# win
 	cp etc/filebeat.yml $(PREFIX)/filebeat-win.yml
-	sed -i 's@#registry_file: .filebeat@registry_file: "C:/ProgramData/\filebeat/registry"@' $(PREFIX)/filebeat-win.yml
+	sed -i 's@#registry_file: .filebeat@registry_file: "C:/ProgramData/filebeat/registry"@' $(PREFIX)/filebeat-win.yml


### PR DESCRIPTION
By removing the espacing of the F in the registry_path valid YAML is generated again