### PR TITLE
Fix #140: Convert offest and line to long fields to prevent overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All documentation about Filebeat can be found here.
 
 ### Bugfixes
 - Omit 'fields' from event JSON when null. #126
+- Make offset and line value of type long in elasticsearch template to prevent overflow #140
 
 ### Added
 

--- a/etc/filebeat.template.json
+++ b/etc/filebeat.template.json
@@ -29,11 +29,11 @@
           "index": "analyzed"
         },
         "line": {
-          "type": "integer",
+          "type": "long",
           "doc_values": "true"
         },
         "offset": {
-          "type": "integer",
+          "type": "long",
           "doc_values": "true"
         }
       }


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/elastic/filebeat/issues/140