### PR TITLE
Don't ask for the GENERIC_WRITE access on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ All documentation about Filebeat can be found here.
 
 ### Bugfixes
 - Omit 'fields' from event JSON when null. #126
-- Make offset and line value of type long in elasticsearch template to prevent overflow #140
+- Make offset and line value of type long in elasticsearch template to prevent overflow. #140
+- Fix locking files for writing behaviour. #156
 
 ### Added
 

--- a/input/file_windows.go
+++ b/input/file_windows.go
@@ -90,7 +90,7 @@ func ReadOpen(path string) (*os.File, error) {
 	}
 
 	var access uint32
-	access = syscall.GENERIC_READ | syscall.GENERIC_WRITE
+	access = syscall.GENERIC_READ
 
 	sharemode := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE)
 


### PR DESCRIPTION
We don't need it, and in my tests it looks like this is the cause
for #145.

The problem seems to be that if this flag is used, the
other programs see the file as "read only". They can still write
to it, and python just does it, but most programs refused to do it
unless you use the "-force" parameter or similar. This explains why
our python based tests were passing despite this issue :-(.