### PR TITLE
Set ignore_older to 10m by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All documentation about Filebeat can be found here.
 ### Added
 
 ### Improvements
-- All Godeps dependencies were updated to master on 2015-10-21 [#122](https://github.com/elastic/filebeat/pull/122)
+- All Godeps dependencies were updated to master on 2015-10-21 [#122]
+- Set default value for ignore_older config to 10 minutes. #164
 
 ### Deprecated

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"log"
-	"math"
 	"os"
 	"path/filepath"
 	"time"
@@ -14,10 +13,10 @@ import (
 // Defaults for config variables which are not set
 const (
 	DefaultRegistryFile                      = ".filebeat"
-	DefaultIgnoreOlderDuration time.Duration = math.MaxInt64
-	DefaultScanFrequency       time.Duration = 10 * time.Second // 10 seconds
+	DefaultIgnoreOlderDuration time.Duration = 10 * time.Minute
+	DefaultScanFrequency       time.Duration = 10 * time.Second
 	DefaultSpoolSize           uint64        = 1024
-	DefaultIdleTimeout         time.Duration = time.Second * 5
+	DefaultIdleTimeout         time.Duration = 5 * time.Second
 	DefaultHarvesterBufferSize int           = 16 << 10 // 16384
 	DefaultDocumentType                      = "log"
 	DefaultTailOnRotate                      = false

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,7 +34,7 @@ func TestReadConfig(t *testing.T) {
 	assert.Equal(t, "log", prospectors[0].Input)
 	assert.Equal(t, 3, len(prospectors[0].Harvester.Fields))
 	assert.Equal(t, 1, len(prospectors[0].Harvester.Fields["review"]))
-	assert.Equal(t, "24h", prospectors[0].IgnoreOlder)
+	assert.Equal(t, "10m", prospectors[0].IgnoreOlder)
 	assert.Equal(t, "10s", prospectors[0].ScanFrequency)
 
 	assert.Equal(t, "stdin", prospectors[2].Input)

--- a/crawler/prospector.go
+++ b/crawler/prospector.go
@@ -31,6 +31,7 @@ type ProspectorFileStat struct {
 // Init sets up default config for prospector
 func (p *Prospector) Init() error {
 
+	// Setup Ignore Older
 	if p.ProspectorConfig.IgnoreOlder != "" {
 
 		var err error
@@ -47,6 +48,7 @@ func (p *Prospector) Init() error {
 		p.ProspectorConfig.IgnoreOlderDuration = cfg.DefaultIgnoreOlderDuration
 	}
 
+	// Setup Scan Frequency
 	if p.ProspectorConfig.ScanFrequency != "" {
 
 		var err error
@@ -58,20 +60,21 @@ func (p *Prospector) Init() error {
 			return err
 		}
 	} else {
-		logp.Debug("propsector", "Set ignoreOlderDuration to %s", cfg.DefaultIgnoreOlderDuration)
-		// Set it to default
+		logp.Debug("propsector", "Set scanFrequency to %s", cfg.DefaultScanFrequency)
 		p.ProspectorConfig.ScanFrequencyDuration = cfg.DefaultScanFrequency
 	}
 
+	// Setup Buffer Size
 	if p.ProspectorConfig.Harvester.BufferSize == 0 {
 		p.ProspectorConfig.Harvester.BufferSize = cfg.DefaultHarvesterBufferSize
 	}
 
+	// Setup DocumentType
 	if p.ProspectorConfig.Harvester.DocumentType == "" {
 		p.ProspectorConfig.Harvester.DocumentType = cfg.DefaultDocumentType
 	}
 
-	// Init list
+	// Init File Stat list
 	p.prospectorList = make(map[string]ProspectorFileStat)
 
 	return nil

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -2,7 +2,7 @@
 [[filebeat-configuration-details]]
 == Configuration
 
-The configuration file of Filebeat uses http://yaml.org/[YAML] as any other Beat. 
+The configuration file of Filebeat uses http://yaml.org/[YAML] as any other Beat.
 To start with the configuration it is best to have a look at the default configuration. It is described in detail
 what each configuration option is for and how it can be used. Remove the items that are not needed for your setup.
 
@@ -101,8 +101,8 @@ Elasticsearch in the 'input_type' field.
 
 ===== fields
 
-Add optionally couple of fields to be included to the exported fields by the currently configured 
-Filebeat instance. These fields can be freely picked to add additional information to the crawled 
+Add optionally couple of fields to be included to the exported fields by the currently configured
+Filebeat instance. These fields can be freely picked to add additional information to the crawled
 log files for filtering.
 
 [source,yaml]
@@ -116,7 +116,7 @@ fields:
 ===== ignore_older
 
 If set, ignores the files which were modified more then the defined timespan in the past
-Time strings like 2h (2 hours), 5m (5 minutes) can be used.
+Time strings like 2h (2 hours), 5m (5 minutes) can be used. Default is set to 10m.
 
 ===== scan_frequency
 
@@ -137,7 +137,7 @@ Defines the buffer size every harvester uses when fetching the file. By default 
 
 ===== tail_on_rotate
 
-If true, tail on log rotation. By default, it is disabled. 
+If true, tail on log rotation. By default, it is disabled.
 Note:: If enabled, it may skip entries.
 
 ===== spool_size
@@ -191,7 +191,7 @@ filebeat:
 
 ===== encoding
 
-Configures the file encoding for reading file with international characters. The 
+Configures the file encoding for reading file with international characters. The
 supported encodings are:
 
     * plain, utf-8, utf-16be-bom, utf-16be, utf-16le, big5, gb18030, gbk, hzgb2312,

--- a/etc/filebeat.yml
+++ b/etc/filebeat.yml
@@ -38,7 +38,7 @@ filebeat:
 
       # Ignore files which were modified more then the defined timespan in the past
       # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
-      #ignore_older:
+      #ignore_older: 10m
 
       # Type to be published in the 'type' field. For Elasticsearch output,
       # the type defines the document type these entries should be stored

--- a/tests/files/config.yml
+++ b/tests/files/config.yml
@@ -12,7 +12,7 @@ filebeat:
         level: debug
         review: 1
         type: log
-      ignore_older: 24h
+      ignore_older: 10m
       scan_frequency: 10s
       harvester_buffer_size: 5000
 


### PR DESCRIPTION
This will close open files much faster and leads to less open files.
As soon as the prospector scans for new files again and the file has changed,
it will be picked up again.