### PR TITLE
Update logstash migration TLS configuration documentation

### DIFF
--- a/docs/migration.asciidoc
+++ b/docs/migration.asciidoc
@@ -189,11 +189,11 @@ output:
       # The path to your client ssl certificate
       certificate: ./logstash-forwarder.crt
       # The path to your client ssl key
-      certificate-ssl: ./logstash-forwarder.key
+      certificate_key: ./logstash-forwarder.key
 
       # The path to your trusted ssl CA file. This is used
       # to authenticate your downstream server.
-      certificate-authorities:
+      certificate_authorities:
         - ./logstash-forwarder.crt
 
       # Network timeout in seconds.


### PR DESCRIPTION
The migration configuration currently uses dashes for the certificate configuration instead of underscores. Additioinally, the certificate key was incorrectly specified