### PR TITLE
Fix #167. Reload encoding transformer at the end of each file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All documentation about Filebeat can be found here.
   for event stored in elasticsearch. #133
 - Add 'input_type' field to published events reporting the prospector type being used. #133
 - Fix high CPU usage when not connected to Elasticsearch or Logstash. #144
+- Fix issue that files were not crawled anymore when encoding was set to something other then plain. #182
 
 ### Added
 - Rename the timestamp field with @timestamp #168

--- a/harvester/log.go
+++ b/harvester/log.go
@@ -58,15 +58,14 @@ func (h *Harvester) Harvest() {
 	var line uint64 = 0 // Ask registrar about the line number
 
 	h.initOffset()
-
-	var in io.Reader = h.file
-	in = h.encoding(in)
+	in := h.encoding(h.file)
 	reader := bufio.NewReaderSize(in, h.Config.BufferSize)
 	buffer := bytes.NewBuffer(nil)
 
 	var readTimeout = 10 * time.Second
 	lastReadTime := time.Now()
 	for {
+
 		text, bytesread, err := h.readLine(reader, buffer, readTimeout)
 
 		if err != nil {
@@ -75,6 +74,9 @@ func (h *Harvester) Harvest() {
 			if err != nil {
 				return
 			} else {
+				// EOF reached, reset encoding
+				in = h.encoding(h.file)
+				reader = bufio.NewReaderSize(in, h.Config.BufferSize)
 				continue
 			}
 		}

--- a/tests/system/Makefile
+++ b/tests/system/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 PROCESSES ?= 4
-TIMEOUT ?= 90
+TIMEOUT ?= 120
 
 env: env/bin/activate
 env/bin/activate: requirements.txt

--- a/tests/system/config/filebeat.yml.j2
+++ b/tests/system/config/filebeat.yml.j2
@@ -7,13 +7,13 @@ filebeat:
         - {{ path }}
       # Type of the files. Annotated in every documented
       input: log
-      scan_frequency: 1s
+      scan_frequency: 0.5s
       ignore_older: "{{ignoreOlder}}"
       harvester_buffer_size:
       tail_on_rotate: {{tailOnRotate}}
+      encoding: {{encoding | default("utf-8") }}
   spool_size:
   idle_timeout: 0.5s
-  tail_on_rotate:
   registry_file: {{ fb.working_dir + '/' }}{{ registryFile|default(".filebeat")}}
 
 


### PR DESCRIPTION
As the transformer stops working on completion (EOF) it is reset every time EOF is reached.