### PR TITLE
Added the fields_under_root option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ All documentation about Filebeat can be found here.
 ### Improvements
 - All Godeps dependencies were updated to master on 2015-10-21 [#122]
 - Set default value for ignore_older config to 10 minutes. #164
+- Added the fields_under_root setting to optionally store the custom fields top
+level in the output dictionary. #188
 
 ### Deprecated
 

--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,7 @@ type ProspectorConfig struct {
 type HarvesterConfig struct {
 	InputType                  string `yaml:"input_type"`
 	Fields                     map[string]string
+	FieldsUnderRoot            bool   `yaml:"fields_under_root"`
 	BufferSize                 int    `yaml:"harvester_buffer_size"`
 	TailFiles                  bool   `yaml:"tail_files"`
 	Encoding                   string `yaml:"encoding"`

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -59,6 +59,12 @@ filebeat:
       #  level: debug
       #  review: 1
 
+      # Set to true to store the additional fields as top level fields instead
+      # of under the "fields" sub-dictionary. In case of name conflicts with the
+      # fields added by Filebeat itself, the custom fields overwrite the default
+      # fields.
+      #fields_under_root: false
+
       # Ignore files which were modified more then the defined timespan in the past
       # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
       #ignore_older:
@@ -99,7 +105,7 @@ It has two options:
 The type value will be put into each event published to Logstash and
 Elasticsearch in the 'input_type' field.
 
-
+[[configuration-fields]]
 ===== fields
 
 Add optionally couple of fields to be included to the exported fields by the currently configured
@@ -113,6 +119,12 @@ fields:
     review: 1
 
 -------------------------------------------------------------------------------------
+
+===== fields_under_root
+
+If set to true, the custom <<configuration-fields>> are stored as top level into the output
+document instead of being grouped under a `fields` sub-dictionary. In case of conflicts with
+the fields names added by Filebeat, the custom fields overwrite the existing fields.
 
 ===== ignore_older
 

--- a/etc/filebeat.yml
+++ b/etc/filebeat.yml
@@ -36,6 +36,12 @@ filebeat:
       #  level: debug
       #  review: 1
 
+      # Set to true to store the additional fields as top level fields instead
+      # of under the "fields" sub-dictionary. In case of name conflicts with the
+      # fields added by Filebeat itself, the custom fields overwrite the default
+      # fields.
+      #fields_under_root: false
+
       # Ignore files which were modified more then the defined timespan in the past
       # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
       #ignore_older: 10m

--- a/harvester/log.go
+++ b/harvester/log.go
@@ -150,7 +150,7 @@ func (h *Harvester) Harvest() {
 			Fields:       &h.Config.Fields,
 			Fileinfo:     &info,
 		}
-
+		event.SetFieldsUnderRoot(h.Config.FieldsUnderRoot)
 		h.Offset += int64(bytesRead) // Update offset
 		h.SpoolerChan <- event       // ship the new event downstream
 	}

--- a/input/file_test.go
+++ b/input/file_test.go
@@ -111,3 +111,23 @@ func TestFileEventToMapStr(t *testing.T) {
 	_, found := mapStr["fields"]
 	assert.False(t, found)
 }
+
+func TestFieldsUnderRoot(t *testing.T) {
+	event := FileEvent{
+		Fields: &map[string]string{
+			"hello": "world",
+		},
+	}
+	event.SetFieldsUnderRoot(true)
+	mapStr := event.ToMapStr()
+	_, found := mapStr["fields"]
+	assert.False(t, found)
+	assert.Equal(t, "world", mapStr["hello"])
+
+	event.SetFieldsUnderRoot(false)
+	mapStr = event.ToMapStr()
+	_, found = mapStr["hello"]
+	assert.False(t, found)
+	_, found = mapStr["fields"]
+	assert.True(t, found)
+}

--- a/tests/system/config/filebeat.yml.j2
+++ b/tests/system/config/filebeat.yml.j2
@@ -16,6 +16,13 @@ filebeat:
       backoff_factor: 1
       max_backoff: 1s
       force_close_windows_files: {{force_close_windows_files}}
+      {% if fields %}
+      fields:
+      {% for k,v in fields.items() %}
+        {{k}}: {{v}}
+      {% endfor %}
+      {% endif %}
+      fields_under_root: {{"true" if fieldsUnderRoot else "false"}}
   spool_size:
   idle_timeout: 0.5s
   registry_file: {{ fb.working_dir + '/' }}{{ registryFile|default(".filebeat")}}

--- a/tests/system/test_fields.py
+++ b/tests/system/test_fields.py
@@ -1,0 +1,58 @@
+from filebeat import TestCase
+import os
+
+"""
+Tests for the custom fields functionality.
+"""
+
+
+class Test(TestCase):
+    def test_custom_fields(self):
+        """
+        Tests that custom fields show up in the output dict.
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/test.log",
+            fields={"hello": "world"}
+        )
+
+        with open(self.working_dir + "/test.log", "w") as f:
+            f.write("test message\n")
+
+        filebeat = self.start_filebeat()
+        self.wait_until(lambda: self.output_has(lines=1))
+        filebeat.kill_and_wait()
+
+        output = self.read_output()
+        doc = output[0]
+        assert doc["fields.hello"] == "world"
+
+    def test_custom_fields_under_root(self):
+        """
+        Tests that custom fields show up in the output dict under
+        root when fields_under_root option is used.
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/test.log",
+            fields={
+                "hello": "world",
+                "type": "log2",
+                "timestamp": "2"
+            },
+            fieldsUnderRoot=True
+        )
+
+        with open(self.working_dir + "/test.log", "w") as f:
+            f.write("test message\n")
+
+        filebeat = self.start_filebeat()
+        self.wait_until(lambda: self.output_has(lines=1))
+        filebeat.kill_and_wait()
+
+        output = self.read_output()
+        doc = output[0]
+        print doc
+        assert doc["hello"] == "world"
+        assert doc["type"] == "log2"
+        assert doc["timestamp"] == "2"
+        assert "fields" not in doc


### PR DESCRIPTION
If set to true, the fields are inserted top level instead of under
the fields sub-dict. In case of conflicts, the fields overwrite existing
values.

Still need to update docs & changelog, but the code should be complete.