### PR TITLE
Fix to enable prospector to harvest existing files that are modified.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file based on the
 ### Backward Compatibility Breaks
 
 ### Bugfixes
+- Fix to enable prospector to harvest existing files that are modified. #199
 
 ### Added
 

--- a/crawler/prospector.go
+++ b/crawler/prospector.go
@@ -250,6 +250,7 @@ func (p *Prospector) scan(path string, output chan *input.FileEvent) {
 		if !isKnown {
 			p.checkNewFile(&newInfo, file, output)
 		} else {
+			newInfo.Harvester = lastinfo.Harvester
 			p.checkExistingFile(&newInfo, &newFile, &oldFile, file, output)
 		}
 


### PR DESCRIPTION
Filebeat wasn't reading existing files when they were modified. Here's how this issue can be reproduced:

1. `echo "really old line" > /var/log/mylog`
2. `touch -t 201203101513 /var/log/mylog`  # make the file older than the default ignore_older
3. Start filebeat with at least `-d "prospector"` for debug selectors. Wait a few seconds.
4. `echo "now" >> /var/log/mylog`

After updating the file I was expecting to see ["Resuming harvester on an old file that was just modified" ](https://github.com/elastic/filebeat/blob/master/crawler/prospector.go#L365) logged, but I did not. It appears that it is not possible for the block of code to execute because `newInfo.Harvester` is never written to.

This issue was also reported on [discuss.elastic.co](https://discuss.elastic.co/t/file-changes-not-detected-after-a-while/33304/).
