### PR TITLE
Refactor log harvester to simplify it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to this project will be documented in this file based on the
 - Add 'input_type' field to published events reporting the prospector type being used. #133
 - Fix high CPU usage when not connected to Elasticsearch or Logstash. #144
 - Fix issue that files were not crawled anymore when encoding was set to something other then plain. #182
+- Fix issue that for some encoding bytes count instead of rune count was used for offest which lead
+  to restart the file reading from the beginning.
 
 ### Added
 - Introduction of backoff, backoff_factor, max_backoff, partial_line_waiting, force_close_windows_files

--- a/harvester/harvester.go
+++ b/harvester/harvester.go
@@ -2,6 +2,7 @@ package harvester
 
 import (
 	"os"
+	"time"
 
 	"github.com/elastic/filebeat/config"
 	"github.com/elastic/filebeat/input"
@@ -16,6 +17,7 @@ type Harvester struct {
 	SpoolerChan      chan *input.FileEvent
 	encoding         Decoder
 	file             *os.File /* the file being watched */
+	backoff          time.Duration
 }
 
 // Interface for the different harvester types

--- a/harvester/log_test.go
+++ b/harvester/log_test.go
@@ -59,23 +59,20 @@ func TestReadLine(t *testing.T) {
 	buffer := new(bytes.Buffer)
 
 	// Read third line
-	text, bytesread, err := readLine(reader, buffer, 0)
+	text, err := readLine(reader, buffer, 0)
 
 	assert.Equal(t, *text, firstLineString[0:len(firstLineString)-1])
-	assert.Equal(t, bytesread, len(firstLineString))
 	assert.Nil(t, err)
 
 	// read second line
-	text, bytesread, err = readLine(reader, buffer, 0)
+	text, err = readLine(reader, buffer, 0)
 
 	assert.Equal(t, *text, secondLineString[0:len(secondLineString)-1])
-	assert.Equal(t, bytesread, len(secondLineString))
 	assert.Nil(t, err)
 
 	// Read third line, which doesn't exist
-	text, bytesread, err = readLine(reader, buffer, 0)
+	text, err = readLine(reader, buffer, 0)
 	assert.Nil(t, text)
-	assert.Equal(t, bytesread, 0)
 	assert.Equal(t, err, io.EOF)
 }
 

--- a/tests/system/test_crawler.py
+++ b/tests/system/test_crawler.py
@@ -5,7 +5,6 @@ from filebeat import TestCase
 import codecs
 import os
 import time
-import unittest
 
 
 # Additional tests to be added:
@@ -205,7 +204,8 @@ class Test(TestCase):
         """
         Checks that filebeat keeps running in case a log files is deleted
 
-        On Windows this tests in addition if the file was closed as it couldn't be found anymore
+        On Windows this tests in addition if the file was closed as it couldn't
+        be found anymore.
         If Windows does not close the file, a new one can't be created.
         """
 
@@ -344,7 +344,7 @@ class Test(TestCase):
                 f.flush()
 
                 self.wait_until(
-                    lambda: self.output_has( lines_written + 1),
+                    lambda: self.output_has(lines_written + 1),
                     max_timeout=15)
 
         filebeat.kill_and_wait()


### PR DESCRIPTION
Fix issue that for some encoding bytes count instead of rune count was used for offest which lead
to restart the file reading from the beginning.