### PR TITLE
extract line reader handling decoding from harvester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file based on the
 ## [Unreleased](https://github.com/elastic/libbeat/compare/1.0.0-rc1...HEAD)
 
 ### Backward Compatibility Breaks
-- Removed utf-16be-bom encoding support
+- Removed utf-16be-bom encoding support. Support will be added with fix for #205
 
 ### Bugfixes
 - Filebeat will now exit if a configuration error is detected. #198

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ All notable changes to this project will be documented in this file based on the
 ## [Unreleased](https://github.com/elastic/libbeat/compare/1.0.0-rc1...HEAD)
 
 ### Backward Compatibility Breaks
+- Removed utf-16be-bom encoding support
 
 ### Bugfixes
 - Filebeat will now exit if a configuration error is detected. #198
 - Fix to enable prospector to harvest existing files that are modified. #199
+- Improve line reading and encoding to better keep track of file offsets based
+  on encoding. #224
 
 ### Added
 

--- a/harvester/encoding.go
+++ b/harvester/encoding.go
@@ -8,41 +8,41 @@ import (
 	"golang.org/x/text/encoding/charmap"
 	"golang.org/x/text/encoding/htmlindex"
 	"golang.org/x/text/encoding/simplifiedchinese"
-	"golang.org/x/text/encoding/unicode"
-	"golang.org/x/text/transform"
 )
 
 // Decoder wraps a reader for decoding input to utf-8 on read.
 type Decoder func(io.Reader) io.Reader
 
-var encodings = map[string]Decoder{
+var encodings = map[string]encoding.Encoding{
 	// default
 	"nop":   Plain,
 	"plain": Plain,
 
-	// utf8 (validate input) - shadow htmlindex utf8 codecs not validating input
-	"unicode-1-1-utf-8": trans(encoding.UTF8Validator),
-	"utf-8":             trans(encoding.UTF8Validator),
-	"utf8":              trans(encoding.UTF8Validator),
+	/*
+		// utf8 (validate input) - shadow htmlindex utf8 codecs not validating input
+		"unicode-1-1-utf-8": trans(encoding.UTF8Validator),
+		"utf-8":             trans(encoding.UTF8Validator),
+		"utf8":              trans(encoding.UTF8Validator),
+	*/
 
 	// utf16
-	"utf-16be-bom": enc(unicode.UTF16(unicode.BigEndian, unicode.UseBOM)),
+	// "utf-16be-bom": unicode.UTF16(unicode.BigEndian, unicode.UseBOM),
 
 	// simplified chinese
-	"gbk": enc(simplifiedchinese.GBK), // shadow htmlindex using 'GB10830' for GBK
+	"gbk": simplifiedchinese.GBK, // shadow htmlindex using 'GB10830' for GBK
 
 	// 8bit charmap encodings
-	"iso8859-6e": enc(charmap.ISO8859_6E),
-	"iso8859-6i": enc(charmap.ISO8859_6I),
-	"iso8859-8e": enc(charmap.ISO8859_8E),
-	"iso8859-8i": enc(charmap.ISO8859_8I),
+	"iso8859-6e": charmap.ISO8859_6E,
+	"iso8859-6i": charmap.ISO8859_6I,
+	"iso8859-8e": charmap.ISO8859_8E,
+	"iso8859-8i": charmap.ISO8859_8I,
 }
 
 // Plain file encoding not transforming any read bytes.
-var Plain = nopEnc
+var Plain = encoding.Nop
 
 // Find returns
-func findEncoding(name string) (Decoder, bool) {
+func findEncoding(name string) (encoding.Encoding, bool) {
 	if name == "" {
 		return Plain, true
 	}
@@ -52,12 +52,10 @@ func findEncoding(name string) (Decoder, bool) {
 	}
 
 	codec, err := htmlindex.Get(name)
-	if err != nil {
-		return nil, false
-	}
-	return enc(codec), true
+	return codec, err == nil
 }
 
+/*
 func nopEnc(r io.Reader) io.Reader { return r }
 
 func enc(encoding encoding.Encoding) Decoder {
@@ -69,3 +67,4 @@ func trans(t transform.Transformer) Decoder {
 		return transform.NewReader(r, t)
 	}
 }
+*/

--- a/harvester/harvester.go
+++ b/harvester/harvester.go
@@ -3,6 +3,8 @@ package harvester
 import (
 	"os"
 
+	"golang.org/x/text/encoding"
+
 	"github.com/elastic/filebeat/config"
 	"github.com/elastic/filebeat/input"
 )
@@ -14,7 +16,7 @@ type Harvester struct {
 	Offset           int64
 	FinishChan       chan int64
 	SpoolerChan      chan *input.FileEvent
-	encoding         Decoder
+	encoding         encoding.Encoding
 	file             *os.File /* the file being watched */
 }
 

--- a/harvester/log.go
+++ b/harvester/log.go
@@ -316,6 +316,7 @@ func readLine(
 			// return partial line:
 			// XXX: we rather want to drop partial line (like orignial implementation?)
 			line, sz, err = reader.partial()
+			reader.dropPartial()
 			return readlineString(line, sz)
 		}
 

--- a/harvester/log.go
+++ b/harvester/log.go
@@ -163,11 +163,13 @@ func (h *Harvester) Harvest() {
 			Text:         &text,
 			Fields:       &h.Config.Fields,
 			Fileinfo:     &info,
+			IsPartial:    isPartial,
 		}
-		event.SetFieldsUnderRoot(h.Config.FieldsUnderRoot)
 		if !isPartial {
 			h.Offset += int64(bytesRead) // Update offset if complete line has been processed
 		}
+
+		event.SetFieldsUnderRoot(h.Config.FieldsUnderRoot)
 		h.SpoolerChan <- event // ship the new event downstream
 	}
 }

--- a/harvester/log_test.go
+++ b/harvester/log_test.go
@@ -1,8 +1,6 @@
 package harvester
 
 import (
-	"bufio"
-	"bytes"
 	"io"
 	"math/rand"
 	"os"
@@ -55,26 +53,26 @@ func TestReadLine(t *testing.T) {
 	assert.NotNil(t, h)
 
 	// Read only 10 bytes which is not the end of the file
-	reader := bufio.NewReaderSize(readFile, 100)
-	buffer := new(bytes.Buffer)
+	timedIn := newTimedReader(readFile)
+	reader, _ := newLineReader(timedIn, Plain, 100)
 
 	// Read third line
-	text, bytesread, err := readLine(reader, buffer, 0)
+	text, bytesread, err := readLine(reader, &timedIn.lastReadTime, 0)
 
-	assert.Equal(t, *text, firstLineString[0:len(firstLineString)-1])
+	assert.Equal(t, text, firstLineString[0:len(firstLineString)-1])
 	assert.Equal(t, bytesread, len(firstLineString))
 	assert.Nil(t, err)
 
 	// read second line
-	text, bytesread, err = readLine(reader, buffer, 0)
+	text, bytesread, err = readLine(reader, &timedIn.lastReadTime, 0)
 
-	assert.Equal(t, *text, secondLineString[0:len(secondLineString)-1])
+	assert.Equal(t, text, secondLineString[0:len(secondLineString)-1])
 	assert.Equal(t, bytesread, len(secondLineString))
 	assert.Nil(t, err)
 
 	// Read third line, which doesn't exist
-	text, bytesread, err = readLine(reader, buffer, 0)
-	assert.Nil(t, text)
+	text, bytesread, err = readLine(reader, &timedIn.lastReadTime, 0)
+	assert.Equal(t, "", text)
 	assert.Equal(t, bytesread, 0)
 	assert.Equal(t, err, io.EOF)
 }

--- a/harvester/log_test.go
+++ b/harvester/log_test.go
@@ -57,24 +57,27 @@ func TestReadLine(t *testing.T) {
 	reader, _ := newLineReader(timedIn, Plain, 100)
 
 	// Read third line
-	text, bytesread, err := readLine(reader, &timedIn.lastReadTime, 0)
+	text, bytesread, isPartial, err := readLine(reader, &timedIn.lastReadTime, 0)
 
 	assert.Equal(t, text, firstLineString[0:len(firstLineString)-1])
 	assert.Equal(t, bytesread, len(firstLineString))
 	assert.Nil(t, err)
+	assert.False(t, isPartial)
 
 	// read second line
-	text, bytesread, err = readLine(reader, &timedIn.lastReadTime, 0)
+	text, bytesread, isPartial, err = readLine(reader, &timedIn.lastReadTime, 0)
 
 	assert.Equal(t, text, secondLineString[0:len(secondLineString)-1])
 	assert.Equal(t, bytesread, len(secondLineString))
 	assert.Nil(t, err)
+	assert.False(t, isPartial)
 
 	// Read third line, which doesn't exist
-	text, bytesread, err = readLine(reader, &timedIn.lastReadTime, 0)
+	text, bytesread, isPartial, err = readLine(reader, &timedIn.lastReadTime, 0)
 	assert.Equal(t, "", text)
 	assert.Equal(t, bytesread, 0)
 	assert.Equal(t, err, io.EOF)
+	assert.False(t, isPartial)
 }
 
 func TestIsLine(t *testing.T) {

--- a/harvester/reader.go
+++ b/harvester/reader.go
@@ -202,13 +202,20 @@ func (l *lineReader) decode(end int) (int, error) {
 
 func (l *lineReader) partial() ([]byte, int, error) {
 	sz, err := l.decode(l.inBuffer.Len()) // decode all input buffer
-	l.inBuffer.Consume(sz)                // advance by number of decoded bytes
+	l.inBuffer.Advance(sz)
+	l.inBuffer.Reset()
+
 	l.inOffset -= sz
 	if l.inOffset < 0 {
 		l.inOffset = 0
 	}
 
-	bytes, _ := l.outBuffer.Consume(l.outBuffer.Len())
+	bytes, err := l.outBuffer.Collect(l.outBuffer.Len())
+	if err != nil {
+		panic(err)
+	}
+	l.outBuffer.Reset()
+
 	sz = l.byteCount
 	l.byteCount = 0
 	return bytes, sz, err

--- a/harvester/reader.go
+++ b/harvester/reader.go
@@ -1,0 +1,214 @@
+package harvester
+
+import (
+	"io"
+	"time"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/transform"
+
+	"github.com/elastic/libbeat/common/streambuf"
+)
+
+// timedReader keeps track of last time bytes have been read from underlying
+// reader.
+type timedReader struct {
+	reader       io.Reader
+	lastReadTime time.Time // last time we read some data from input stream
+}
+
+// lineReader reads lines from underlying reader, decoding the input stream
+// using the configured codec. The reader keeps track of bytes consumed
+// from raw input stream for every decoded line.
+type lineReader struct {
+	rawInput   io.Reader
+	codec      encoding.Encoding
+	bufferSize int
+
+	nl        []byte
+	inBuffer  *streambuf.Buffer
+	outBuffer *streambuf.Buffer
+	inOffset  int // input buffer read offset
+	byteCount int // number of bytes decoded from input buffer into output buffer
+	decoder   transform.Transformer
+}
+
+const maxConsecutiveEmptyReads = 100
+
+func newTimedReader(reader io.Reader) *timedReader {
+	r := &timedReader{
+		reader: reader,
+	}
+	return r
+}
+
+func (r *timedReader) Read(p []byte) (int, error) {
+	var err error
+	n := 0
+
+	for i := maxConsecutiveEmptyReads; i > 0; i-- {
+		n, err = r.reader.Read(p)
+		if n > 0 {
+			r.lastReadTime = time.Now()
+			break
+		}
+
+		if err != nil {
+			break
+		}
+	}
+
+	return n, err
+}
+
+func newLineReader(
+	input io.Reader,
+	codec encoding.Encoding,
+	bufferSize int,
+) (*lineReader, error) {
+	l := &lineReader{}
+
+	if err := l.init(input, codec, bufferSize); err != nil {
+		return nil, err
+	}
+
+	return l, nil
+}
+
+func (l *lineReader) init(
+	input io.Reader,
+	codec encoding.Encoding,
+	bufferSize int,
+) error {
+	l.rawInput = input
+	l.codec = codec
+	l.bufferSize = bufferSize
+
+	l.codec.NewEncoder()
+	nl, _, err := transform.Bytes(l.codec.NewEncoder(), []byte{'\n'})
+	if err != nil {
+		return err
+	}
+
+	l.nl = nl
+	l.decoder = l.codec.NewDecoder()
+	l.inBuffer = streambuf.New(nil)
+	l.outBuffer = streambuf.New(nil)
+	return nil
+}
+
+func (l *lineReader) next() ([]byte, int, error) {
+	for {
+		// read next 'potential' line from input buffer/reader
+		err := l.advance()
+		if err != nil {
+			return nil, 0, err
+		}
+
+		// check last decoded byte really being '\n'
+		buf := l.outBuffer.Bytes()
+		if buf[len(buf)-1] == '\n' {
+			break
+		}
+	}
+
+	// output buffer contains complete line ending with '\n'. Extract
+	// byte slice from buffer and reset output buffer.
+	bytes, err := l.outBuffer.Collect(l.outBuffer.Len())
+	if err != nil {
+		panic(err)
+	}
+
+	// return and reset consumed bytes count
+	sz := l.byteCount
+	l.byteCount = 0
+	return bytes, sz, nil
+}
+
+func (l *lineReader) advance() error {
+	var idx int
+
+	// fill inBuffer until '\n' sequence has been found in input buffer
+	for {
+		idx = l.inBuffer.IndexFrom(l.inOffset, l.nl)
+		if idx > 0 {
+			break
+		}
+
+		// increase search offset to reduce iterations on buffer when looping
+		newOffset := l.inBuffer.Len() - len(l.nl)
+		if newOffset > l.inOffset {
+			l.inOffset = newOffset
+		}
+
+		// try to read more bytes into buffer
+		n := 0
+		buf := make([]byte, l.bufferSize)
+		n, err := l.rawInput.Read(buf)
+		l.inBuffer.Append(buf[:n])
+		if err != nil {
+			return err
+		}
+
+		// empty read => return buffer error (more bytes required error)
+		if n == 0 {
+			return streambuf.ErrNoMoreBytes
+		}
+	}
+
+	// found encoded byte sequence for '\n' in buffer
+	// -> decode input sequence into outBuffer
+	sz, err := l.decode(idx + len(l.nl))
+
+	// consume transformed bytes from input buffer
+	err = l.inBuffer.Advance(sz)
+	l.inBuffer.Reset()
+
+	l.inOffset = idx + 1 - sz // continue scanning input buffer from last position + 1
+	if l.inOffset < 0 {
+		// fix inOffset if '\n' has encoding > 8bits + fill line has been decoded
+		l.inOffset = 0
+	}
+
+	return err
+}
+
+func (l *lineReader) decode(end int) (int, error) {
+	var err error
+	buffer := make([]byte, 1024)
+	inBytes := l.inBuffer.Bytes()
+	start := 0
+
+	for start < end {
+		var nDst, nSrc int
+
+		nDst, nSrc, err = l.decoder.Transform(buffer, inBytes[start:end], false)
+		start += nSrc
+
+		l.outBuffer.Append(buffer[:nDst])
+
+		if err != nil {
+			if err == transform.ErrShortDst { // continue transforming
+				continue
+			}
+			break
+		}
+	}
+
+	l.byteCount += start
+	return start, err
+}
+
+func (l *lineReader) partial() ([]byte, int, error) {
+	sz, err := l.decode(l.inBuffer.Len()) // decode all input buffer
+	l.inBuffer.Consume(sz)                // advance by number of decoded bytes
+	l.inOffset -= sz
+	if l.inOffset < 0 {
+		l.inOffset = 0
+	}
+
+	bytes, _ := l.outBuffer.Consume(l.outBuffer.Len())
+	sz = l.byteCount
+	l.byteCount = 0
+	return bytes, sz, err
+}

--- a/harvester/reader.go
+++ b/harvester/reader.go
@@ -115,6 +115,7 @@ func (l *lineReader) next() ([]byte, int, error) {
 	// output buffer contains complete line ending with '\n'. Extract
 	// byte slice from buffer and reset output buffer.
 	bytes, err := l.outBuffer.Collect(l.outBuffer.Len())
+	l.outBuffer.Reset()
 	if err != nil {
 		panic(err)
 	}

--- a/harvester/reader.go
+++ b/harvester/reader.go
@@ -128,12 +128,17 @@ func (l *lineReader) next() ([]byte, int, error) {
 
 func (l *lineReader) advance() error {
 	var idx int
+	var err error
 
 	// fill inBuffer until '\n' sequence has been found in input buffer
 	for {
 		idx = l.inBuffer.IndexFrom(l.inOffset, l.nl)
-		if idx > 0 {
+		if idx >= 0 {
 			break
+		}
+		if err != nil {
+			// if no newline and last read returned error, return error now
+			return err
 		}
 
 		// increase search offset to reduce iterations on buffer when looping
@@ -147,7 +152,8 @@ func (l *lineReader) advance() error {
 		buf := make([]byte, l.bufferSize)
 		n, err := l.rawInput.Read(buf)
 		l.inBuffer.Append(buf[:n])
-		if err != nil {
+
+		if n == 0 && err != nil {
 			return err
 		}
 

--- a/harvester/reader_test.go
+++ b/harvester/reader_test.go
@@ -9,22 +9,22 @@ import (
 	"golang.org/x/text/transform"
 )
 
-func TestReaderEncodings(t *testing.T) {
-	// Sample texts are from http://www.columbia.edu/~kermit/utf8.html
-	var tests = []struct {
-		encoding string
-		lines    []string
-	}{
-		{"plain", []string{"I can", "eat glass"}},
-		{"latin1", []string{"I kå Glas frässa", "ond des macht mr nix!"}},
-		{"utf-16be", []string{"Pot să mănânc sticlă", "și ea nu mă rănește."}},
-		{"utf-16le", []string{"काचं शक्नोम्यत्तुम् ।", "नोपहिनस्ति माम् ॥"}},
-		{"big5", []string{"我能吞下玻", "璃而不傷身體。"}},
-		{"gb18030", []string{"我能吞下玻璃", "而不傷身。體"}},
-		{"euc-kr", []string{" 나는 유리를 먹을 수 있어요.", " 그래도 아프지 않아요"}},
-		{"euc-jp", []string{"私はガラスを食べられます。", "それは私を傷つけません。"}},
-	}
+// Sample texts are from http://www.columbia.edu/~kermit/utf8.html
+var tests = []struct {
+	encoding string
+	strings  []string
+}{
+	{"plain", []string{"I can", "eat glass"}},
+	{"latin1", []string{"I kå Glas frässa", "ond des macht mr nix!"}},
+	{"utf-16be", []string{"Pot să mănânc sticlă", "și ea nu mă rănește."}},
+	{"utf-16le", []string{"काचं शक्नोम्यत्तुम् ।", "नोपहिनस्ति माम् ॥"}},
+	{"big5", []string{"我能吞下玻", "璃而不傷身體。"}},
+	{"gb18030", []string{"我能吞下玻璃", "而不傷身。體"}},
+	{"euc-kr", []string{" 나는 유리를 먹을 수 있어요.", " 그래도 아프지 않아요"}},
+	{"euc-jp", []string{"私はガラスを食べられます。", "それは私を傷つけません。"}},
+}
 
+func TestReaderEncodings(t *testing.T) {
 	for _, test := range tests {
 		t.Logf("test codec: %v", test.encoding)
 
@@ -39,7 +39,7 @@ func TestReaderEncodings(t *testing.T) {
 		// write with encoding to buffer
 		writer := transform.NewWriter(buffer, codec.NewEncoder())
 		var expectedCount []int
-		for _, line := range test.lines {
+		for _, line := range test.strings {
 			writer.Write([]byte(line))
 			writer.Write([]byte{'\n'})
 			expectedCount = append(expectedCount, buffer.Len())
@@ -71,16 +71,62 @@ func TestReaderEncodings(t *testing.T) {
 		}
 
 		// validate lines and byte offsets
-		if len(test.lines) != len(readLines) {
+		if len(test.strings) != len(readLines) {
 			t.Errorf("number of lines mismatch (expected=%v actual=%v)",
-				len(test.lines), len(readLines))
+				len(test.strings), len(readLines))
 			continue
 		}
-		for i := range test.lines {
-			expected := test.lines[i]
+		for i := range test.strings {
+			expected := test.strings[i]
 			actual := readLines[i]
 			assert.Equal(t, expected, actual)
 			assert.Equal(t, expectedCount[i], byteCounts[i])
+		}
+	}
+}
+
+func TestReaderPartialWithEncodings(t *testing.T) {
+	for _, test := range tests {
+		t.Logf("test codec: %v", test.encoding)
+
+		codec, ok := findEncoding(test.encoding)
+		if !ok {
+			t.Errorf("can not find encoding '%v'", test.encoding)
+			continue
+		}
+
+		buffer := bytes.NewBuffer(nil)
+		writer := transform.NewWriter(buffer, codec.NewEncoder())
+		reader, err := newLineReader(buffer, codec, 1024)
+		if err != nil {
+			t.Errorf("failed to initialize reader: %v", err)
+			continue
+		}
+
+		var partials []string
+		for _, str := range test.strings {
+			writer.Write([]byte(str))
+
+			line, sz, err := reader.next()
+			assert.NotNil(t, err)
+			assert.Equal(t, 0, sz)
+			assert.Nil(t, line)
+
+			partial, _, err := reader.partial()
+			partials = append(partials, string(partial))
+			t.Logf("partials: %v", partials)
+		}
+
+		// validate partial lines
+		if len(test.strings) != len(partials) {
+			t.Errorf("number of lines mismatch (expected=%v actual=%v)",
+				len(test.strings), len(partials))
+			continue
+		}
+		for i := range test.strings {
+			expected := test.strings[i]
+			actual := partials[i]
+			assert.Equal(t, expected, actual)
 		}
 	}
 }

--- a/harvester/reader_test.go
+++ b/harvester/reader_test.go
@@ -1,0 +1,86 @@
+package harvester
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"golang.org/x/text/transform"
+)
+
+func TestReaderEncodings(t *testing.T) {
+	// Sample texts are from http://www.columbia.edu/~kermit/utf8.html
+	var tests = []struct {
+		encoding string
+		lines    []string
+	}{
+		{"plain", []string{"I can", "eat glass"}},
+		{"latin1", []string{"I kå Glas frässa", "ond des macht mr nix!"}},
+		{"utf-16be", []string{"Pot să mănânc sticlă", "și ea nu mă rănește."}},
+		{"utf-16le", []string{"काचं शक्नोम्यत्तुम् ।", "नोपहिनस्ति माम् ॥"}},
+		{"big5", []string{"我能吞下玻", "璃而不傷身體。"}},
+		{"gb18030", []string{"我能吞下玻璃", "而不傷身。體"}},
+		{"euc-kr", []string{" 나는 유리를 먹을 수 있어요.", " 그래도 아프지 않아요"}},
+		{"euc-jp", []string{"私はガラスを食べられます。", "それは私を傷つけません。"}},
+	}
+
+	for _, test := range tests {
+		t.Logf("test codec: %v", test.encoding)
+
+		codec, ok := findEncoding(test.encoding)
+		if !ok {
+			t.Errorf("can not find encoding '%v'", test.encoding)
+			continue
+		}
+
+		buffer := bytes.NewBuffer(nil)
+
+		// write with encoding to buffer
+		writer := transform.NewWriter(buffer, codec.NewEncoder())
+		var expectedCount []int
+		for _, line := range test.lines {
+			writer.Write([]byte(line))
+			writer.Write([]byte{'\n'})
+			expectedCount = append(expectedCount, buffer.Len())
+		}
+
+		// create line reader
+		reader, err := newLineReader(buffer, codec, 1024)
+		if err != nil {
+			t.Errorf("failed to initialize reader: %v", err)
+			continue
+		}
+
+		// read decodec lines from buffer
+		var readLines []string
+		var byteCounts []int
+		current := 0
+		for {
+			bytes, sz, err := reader.next()
+			if sz > 0 {
+				readLines = append(readLines, string(bytes[:len(bytes)-1]))
+			}
+
+			if err != nil {
+				break
+			}
+
+			current += sz
+			byteCounts = append(byteCounts, current)
+		}
+
+		// validate lines and byte offsets
+		if len(test.lines) != len(readLines) {
+			t.Errorf("number of lines mismatch (expected=%v actual=%v)",
+				len(test.lines), len(readLines))
+			continue
+		}
+		for i := range test.lines {
+			expected := test.lines[i]
+			actual := readLines[i]
+			assert.Equal(t, expected, actual)
+			assert.Equal(t, expectedCount[i], byteCounts[i])
+		}
+	}
+}

--- a/input/file.go
+++ b/input/file.go
@@ -26,6 +26,7 @@ type FileEvent struct {
 	Text         *string
 	Fields       *map[string]string
 	Fileinfo     *os.FileInfo
+	IsPartial    bool
 
 	fieldsUnderRoot bool
 }
@@ -68,6 +69,10 @@ func (f *FileEvent) ToMapStr() common.MapStr {
 		"fileinfo":   f.Fileinfo,
 		"type":       f.DocumentType,
 		"input_type": f.InputType,
+	}
+
+	if f.IsPartial {
+		event["partial"] = true
 	}
 
 	if f.Fields != nil {


### PR DESCRIPTION
split line reader from harvester. reader separates lines, applies the configured codec + while reading lines it keeps track of total bytes consumed from raw input stream (speak: correct file offset in bytes). 