### PR TITLE
File state offset based on input bytes

### DIFF
--- a/harvester/log.go
+++ b/harvester/log.go
@@ -160,6 +160,7 @@ func (h *Harvester) Harvest() {
 			InputType:    h.Config.InputType,
 			DocumentType: h.Config.DocumentType,
 			Offset:       h.Offset,
+			Bytes:        bytesRead,
 			Text:         &text,
 			Fields:       &h.Config.Fields,
 			Fileinfo:     &info,


### PR DESCRIPTION
Update file state input to be based on bytes read from input to properly handle
offsets for different newline patterns and encodings.