### PR TITLE
Input type fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file based on the
 - Fix to enable prospector to harvest existing files that are modified. #199
 - Improve line reading and encoding to better keep track of file offsets based
   on encoding. #224
+- Set input_type by default to "log"
 
 ### Added
 - Handling end of line under windows was improved #233

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ const (
 	DefaultSpoolSize           uint64        = 1024
 	DefaultIdleTimeout         time.Duration = 5 * time.Second
 	DefaultHarvesterBufferSize int           = 16 << 10 // 16384
+	DefaultInputType                      = "log"
 	DefaultDocumentType                      = "log"
 	DefaultTailFiles                         = false
 	DefaultBackoff                           = 1 * time.Second

--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,7 @@ const (
 	DefaultSpoolSize           uint64        = 1024
 	DefaultIdleTimeout         time.Duration = 5 * time.Second
 	DefaultHarvesterBufferSize int           = 16 << 10 // 16384
-	DefaultInputType                      = "log"
+	DefaultInputType                         = "log"
 	DefaultDocumentType                      = "log"
 	DefaultTailFiles                         = false
 	DefaultBackoff                           = 1 * time.Second

--- a/crawler/prospector.go
+++ b/crawler/prospector.go
@@ -82,6 +82,11 @@ func (p *Prospector) setupHarvesterConfig() error {
 		config.DocumentType = cfg.DefaultDocumentType
 	}
 
+	// Setup InputType
+	if config.InputType == "" {
+		config.InputType = cfg.DefaultInputType
+	}
+
 	config.BackoffDuration, err = getConfigDuration(config.Backoff, cfg.DefaultBackoff, "backoff")
 	if err != nil {
 		return err

--- a/input/file.go
+++ b/input/file.go
@@ -23,7 +23,6 @@ type FileEvent struct {
 	DocumentType string
 	Offset       int64
 	Bytes        int
-	Line         uint64
 	Text         *string
 	Fields       *map[string]string
 	Fileinfo     *os.FileInfo
@@ -68,9 +67,7 @@ func (f *FileEvent) ToMapStr() common.MapStr {
 		"@timestamp": common.Time(f.ReadTime),
 		"source":     f.Source,
 		"offset":     f.Offset,
-		"line":       f.Line,
 		"message":    f.Text,
-		"fileinfo":   f.Fileinfo,
 		"type":       f.DocumentType,
 		"input_type": f.InputType,
 	}


### PR DESCRIPTION
* Removing line from document which is sent. This was already mentioned in RC1 that it should be removed. Was not removed in all places.
* Removing fileinfo from event. This was always empty.