### PR TITLE
Use type: dict for fields of that type

### DIFF
--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -90,12 +90,20 @@ required: True
 Content of line read from log file given by source.
 
 
-==== fields Fields
+==== fields
+
+type: dict
+
+required: False
 
 Contains user configurable fields.
 
 
-==== fileinfo Fields
+==== fileinfo
+
+type: dict
+
+required: False
 
 Operating System specific file information use to identify the source file. For example on linux an inode might be reported.
 

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -99,12 +99,3 @@ required: False
 Contains user configurable fields.
 
 
-==== fileinfo
-
-type: dict
-
-required: False
-
-Operating System specific file information use to identify the source file. For example on linux an inode might be reported.
-
-

--- a/etc/fields.yml
+++ b/etc/fields.yml
@@ -66,13 +66,13 @@ log:
         Content of line read from log file given by source.
 
     - name: fields
-      type: group
+      type: dict
       required: false
       description: >
         Contains user configurable fields.
 
     - name: fileinfo
-      type: group
+      type: dict
       required: false
       description: >
         Operating System specific file information use to identify the source

--- a/etc/fields.yml
+++ b/etc/fields.yml
@@ -70,10 +70,3 @@ log:
       required: false
       description: >
         Contains user configurable fields.
-
-    - name: fileinfo
-      type: dict
-      required: false
-      description: >
-        Operating System specific file information use to identify the source
-        file. For example on linux an inode might be reported.


### PR DESCRIPTION
It used to be type: group, but that is interpreted by the docs
generating script to mean that it has documented sub-fields.

@dedemorton can you review the result, please?