### PR TITLE
Fix buffer array being reused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Bugfixes
 - Fix problem that harvesters stopped reading after some time and filebeat stopped processing events #257
+- Fix line truncating by internal buffers being reused by accident #258
 
 ### Added
 

--- a/harvester/reader.go
+++ b/harvester/reader.go
@@ -193,7 +193,7 @@ func (l *lineReader) decode(end int) (int, error) {
 		nDst, nSrc, err = l.decoder.Transform(buffer, inBytes[start:end], false)
 		start += nSrc
 
-		l.outBuffer.Append(buffer[:nDst])
+		l.outBuffer.Write(buffer[:nDst])
 
 		if err != nil {
 			if err == transform.ErrShortDst { // continue transforming


### PR DESCRIPTION
Resolves #258

Use write instead of append, so read buffer used when decoding a line
is not reused.

Add unit test for long lines being processed correctly.