### PR TITLE
prospector and harvester state sharing refactoring

### DIFF
--- a/harvester/harvester.go
+++ b/harvester/harvester.go
@@ -5,9 +5,10 @@ import (
 
 	"golang.org/x/text/encoding"
 
+	"time"
+
 	"github.com/elastic/filebeat/config"
 	"github.com/elastic/filebeat/input"
-	"time"
 )
 
 type Harvester struct {
@@ -15,11 +16,18 @@ type Harvester struct {
 	ProspectorConfig config.ProspectorConfig
 	Config           *config.HarvesterConfig
 	Offset           int64
-	FinishChan       chan int64
+	Stat             *FileStat
 	SpoolerChan      chan *input.FileEvent
 	encoding         encoding.Encoding
 	file             *os.File /* the file being watched */
 	backoff          time.Duration
+}
+
+// Contains statistic about file when it was last seend by the prospector
+type FileStat struct {
+	Fileinfo      os.FileInfo /* the file info */
+	Return        chan int64  /* the harvester will send an event with its offset when it closes */
+	LastIteration uint32      /* int number of the last iterations in which we saw this file */
 }
 
 // Interface for the different harvester types
@@ -32,4 +40,33 @@ func (h *Harvester) Start() {
 	// Starts harvester and picks the right type. In case type is not set, set it to defeault (log)
 
 	go h.Harvest()
+}
+
+func NewFileStat(fi os.FileInfo, lastIteration uint32) *FileStat {
+	fs := &FileStat{
+		Fileinfo:      fi,
+		Return:        make(chan int64, 1),
+		LastIteration: lastIteration,
+	}
+	return fs
+}
+
+func (fs *FileStat) Finished() bool {
+	return len(fs.Return) != 0
+}
+
+// Ignore forgets about the previous harvester results and let it continue on the old
+// file - start a new channel to use with the new harvester.
+func (fs *FileStat) Ignore() {
+	fs.Return = make(chan int64, 1)
+}
+
+func (fs *FileStat) Continue(old *FileStat) {
+	if old != nil {
+		fs.Return = old.Return
+	}
+}
+
+func (fs *FileStat) Skip(returnOffset int64) {
+	fs.Return <- returnOffset
 }

--- a/harvester/log.go
+++ b/harvester/log.go
@@ -16,7 +16,7 @@ func NewHarvester(
 	prospectorCfg config.ProspectorConfig,
 	cfg *config.HarvesterConfig,
 	path string,
-	signal chan int64,
+	stat *FileStat,
 	spooler chan *input.FileEvent,
 ) (*Harvester, error) {
 	encoding, ok := findEncoding(cfg.Encoding)
@@ -28,7 +28,7 @@ func NewHarvester(
 		Path:             path,
 		ProspectorConfig: prospectorCfg,
 		Config:           cfg,
-		FinishChan:       signal,
+		Stat:             stat,
 		SpoolerChan:      spooler,
 		encoding:         encoding,
 		backoff:          prospectorCfg.Harvester.BackoffDuration,
@@ -43,7 +43,7 @@ func (h *Harvester) Harvest() {
 
 	defer func() {
 		// On completion, push offset so we can continue where we left off if we relaunch on the same file
-		h.FinishChan <- h.Offset
+		h.Stat.Return <- h.Offset
 		// Make sure file is closed as soon as harvester exits
 		h.file.Close()
 	}()

--- a/tests/system/test_prospector.py
+++ b/tests/system/test_prospector.py
@@ -90,7 +90,6 @@ class Test(TestCase):
                 "Harvester started for file: -"),
             max_timeout=10)
 
-
         iterations1 = 5
         for n in range(0, iterations1):
             os.write(proc.stdin_write, "Hello World\n")
@@ -98,7 +97,6 @@ class Test(TestCase):
         self.wait_until(
             lambda: self.output_has(lines=iterations1),
             max_timeout=15)
-
 
         iterations2 = 10
         for n in range(0, iterations2):


### PR DESCRIPTION
Refactor sharing processing state between prospector and harvester
by moving crawler.ProspectorFileStat to harvester.FileStat
and sharing the FileStat between harvester and prospector instead
of just the channel.

Helps with problems of the prospector reassigning the channel besides
having the harvester already initialized with another channel. So harvester
will send processing return value to correct channel.