### PR TITLE
Adds the word Reference to the doc title

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-= Filebeat
+= Filebeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.0.0
 :version: 1.0.0
 


### PR DESCRIPTION
This change got lost during some cherry picking or merging or something. 