### PR TITLE
Publish test results to S3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,12 @@ go:
   - 1.5.1
 
 env:
+  matrix:
   - TARGETS="check testsuite"
   - TARGETS="crosscompile"
+  global:
+  - secure: tbHhtofeRgIJnnWaFr5+Wui9QH96/Jn3qSsG8EuF3HCfoW4cpdBDx8G2buw4Dn6DSD5ZKMlZC5SbYT+3BCs+HUSszscvgr1wd1QDx1sBrUb+3uGI+oj7QnFpS48nrslP+SQIJuYr2HhYNHOWxQerQjxsQ2K184xMhHzW9U8sRjW+/msVCak3vwaXIMlS9+tWS8ImlnzmlDe3sSFm80/cZ7b2+cQQdXqzRAMxl/WGYIwv7z2YMPlNI3DVmtglOXbWusjX4l2a6Q6KBAbZrGH4VMKkTPtkAa32MnEKyBv//LZ1/OV8yYH45TY44tLNn5XD6PwicW6kZFtfGetsABnkkSY42hRyZGAtHLSLRJasD2QZRw9QOUuPToNWEPabcvAqI+GFwpwRFZz1PyAR5s7azhGn2pqLScCXx/ZZv1a6SJPf5R6ZFm5RHekwbUhhbEUela6J7AA9AesEoInJVYr0WIDipgfOyr2tHmm3/TCEA3JOgw5pVdzQ+CBs/DDTxxPZy7D5O+PDa2z/LNMmoWLB7/itA/p/9JRWM56Frj9O9jubEecEC+s/2R55T/x8dLLqS0A2f+eiMjs9++1uVjKE7ySny6IzsxL9hfeF8hhhps6hyBM8+nNmHZSAC2CZn0uWdMkaSvlTygQFatr2bgCTwKfniObJDjqAwZk4hmqCHuA=
+  - secure: xa1XNko/KMiHjHwbJyit1bndYWK4Ci3kUd+9L2dxzHXUPK0t/cfLGslKkavY1lYJ9D88iNov01tDPA3iTnFt/k773TRFPMc/taGxv2h0AFMFMqx6zE+qhYe5plTEpisH6SZ6l1vosIR2S4NzmFBtNkY9AedwuUZiNaeMS/l5BdG8o53e/e8jpCFCeN1WMiYqB+iIn99zJVYKsmq9lfIJdZOZR/uqTWf8t3NODHws6+8T0JUOsnfVcX+ithYqI69V2q6/hdfTmNKaKxcf7jfpBAlE/VRTHFan0QVFn6L0VtrNF3X/nqkONV87jeQlPiaBacU8j6agWlUiOudOFy/LKQivoA12W87tuA7wSnX0eg+OXba8e2LlwgcaRyPFdYWU3GNJ940HX89S9GlNuGKJHe6sf9E9ItMdJwb+k3Db7lLUdnr9tMEQGEwp6rMSYk2x/1QgjRSg5QSpg2oZpV06zyuRiU1oIzO5TU3+PbrPyymD0Q1ew2m84bXfM17OYPgDFZCA0afJDUR2XQLkFV2iy77JhSqHymgMfOw79/v14fwnGbSkC+mbvLIrM2uTiB6nhUJ5sHiPTopysdl4B9y4Kw2TG/Krd1pWisiAIgmfAP3djAjA13Swfkj77vOVKExy7ABPRDK7SLu6cxfLeJCEwu/VHlijCMJHCxQv8TPZzy0=
 
 # Only execute the crosscompile target one time during the build.
 matrix:
@@ -26,6 +30,8 @@ addons:
       - geoip-database
 
 before_install:
+  - pip install --user awscli
+  - export PATH=$PATH:$(python -m site --user-base)/bin
   # Redo the travis setup but with the elastic/filebeat path. This is needed so the package path is correct
   - mkdir -p $HOME/gopath/src/github.com/elastic/filebeat
   - rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/elastic/filebeat/
@@ -46,3 +52,11 @@ notifications:
 after_success:
   # Copy profile.cov to coverage.txt because codecov.io requires this file
   - test -f build/coverage/full.cov && bash <(curl -s https://codecov.io/bash) -f build/coverage/full.cov
+
+after_script:
+  # Only publish non-pull request builds because credentials are required.
+  - if [ "$TRAVIS_PULL_REQUEST" == "true" ] && [ "$TRAVIS_REPO_SLUG" == "elastic/filebeat" ] && [ -e "build/system-tests/run" ] ; then
+      export OUTPUT_FILE="system-test-output_job-$TRAVIS_JOB_NUMBER-$TRAVIS_BUILD_ID.zip";
+      zip -r $OUTPUT_FILE build/system-tests/run;
+      aws s3 cp $OUTPUT_FILE s3://beats-nightlies/travis-ci/filebeat/$TRAVIS_BUILD_NUMBER/ --acl public-read;
+    fi


### PR DESCRIPTION
This will zip up the system test results for non-pull-request builds and publish them to S3. Unfortunately publishing can only occur for non-pull-request builds because the secure credentials are [not available](https://github.com/travis-ci/travis-ci/issues/1500#issuecomment-40357069) to pull request builds in order protect them. The URL will be:

`https://beats-nightlies.s3.amazonaws.com/index.html?prefix=travis-ci/filebeat/$TRAVIS_BUILD_NUMBER/job-$TRAVIS_JOB_NUMBER-$TRAVIS_BUILD_ID.zip`

`https://beats-nightlies.s3.amazonaws.com/index.html?prefix=travis-ci/filebeat/767/system-test-output_job-767.1-92982051.zip`

Some example values of the available travis env vars:
```
TRAVIS=true
TRAVIS_BRANCH=master
TRAVIS_BUILD_ID=92982051
TRAVIS_BUILD_NUMBER=767
TRAVIS_COMMIT=4d002a107a3c87fc62589e47cf3679a7cee86b72
TRAVIS_JOB_ID=92982052
TRAVIS_JOB_NUMBER=767.1
TRAVIS_PULL_REQUEST=289
TRAVIS_REPO_SLUG=elastic/filebeat
TRAVIS_SECURE_ENV_VARS=false
```