### PR TITLE
Fixed Appveyor badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Jenkins Build Status](http://build-eu-00.elastic.co/job/filebeat/badge/icon)](http://build-eu-00.elastic.co/job/filebeat/)
 [![Travis Build Status](https://travis-ci.org/elastic/filebeat.svg?branch=master)](https://travis-ci.org/elastic/filebeat)
-[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/knhucktyp2r0q78g/branch/master?svg=true)](https://ci.appveyor.com/project/elastic-beats/filebeat/branch/master)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/lirttsafxqdhwiu1/branch/master?svg=true)](https://ci.appveyor.com/project/elastic-beats/filebeat/branch/master)
 [![codecov.io](http://codecov.io/github/elastic/filebeat/coverage.svg?branch=master)](http://codecov.io/github/elastic/filebeat?branch=master)
 
 


### PR DESCRIPTION
Looks like the project id changed at some point, and we didn't
update the badge.