### PR TITLE
Partial_line_waiting Removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file based on the
 ## [Unreleased](https://github.com/elastic/filebeat/compare/1.0.0...HEAD)
 
 ### Backward Compatibility Breaks
+- Removal of partial_line_waiting config as it was not working as expected. #296
 
 ### Bugfixes
 

--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,6 @@ const (
 	DefaultBackoff                           = 1 * time.Second
 	DefaultBackoffFactor                     = 2
 	DefaultMaxBackoff                        = 10 * time.Second
-	DefaultPartialLineWaiting                = 5 * time.Second
 	DefaultForceCloseFiles                   = false
 )
 
@@ -52,21 +51,19 @@ type ProspectorConfig struct {
 }
 
 type HarvesterConfig struct {
-	InputType                  string `yaml:"input_type"`
-	Fields                     map[string]string
-	FieldsUnderRoot            bool   `yaml:"fields_under_root"`
-	BufferSize                 int    `yaml:"harvester_buffer_size"`
-	TailFiles                  bool   `yaml:"tail_files"`
-	Encoding                   string `yaml:"encoding"`
-	DocumentType               string `yaml:"document_type"`
-	Backoff                    string `yaml:"backoff"`
-	BackoffDuration            time.Duration
-	BackoffFactor              int    `yaml:"backoff_factor"`
-	MaxBackoff                 string `yaml:"max_backoff"`
-	MaxBackoffDuration         time.Duration
-	PartialLineWaiting         string `yaml:"partial_line_wating"`
-	PartialLineWaitingDuration time.Duration
-	ForceCloseFiles            bool `yaml:"force_close_files"`
+	InputType          string `yaml:"input_type"`
+	Fields             map[string]string
+	FieldsUnderRoot    bool   `yaml:"fields_under_root"`
+	BufferSize         int    `yaml:"harvester_buffer_size"`
+	TailFiles          bool   `yaml:"tail_files"`
+	Encoding           string `yaml:"encoding"`
+	DocumentType       string `yaml:"document_type"`
+	Backoff            string `yaml:"backoff"`
+	BackoffDuration    time.Duration
+	BackoffFactor      int    `yaml:"backoff_factor"`
+	MaxBackoff         string `yaml:"max_backoff"`
+	MaxBackoffDuration time.Duration
+	ForceCloseFiles    bool `yaml:"force_close_files"`
 }
 
 // getConfigFiles returns list of config files.

--- a/crawler/prospector.go
+++ b/crawler/prospector.go
@@ -96,9 +96,10 @@ func (p *Prospector) setupHarvesterConfig() error {
 		return err
 	}
 
-	config.PartialLineWaitingDuration, err = getConfigDuration(config.PartialLineWaiting, cfg.DefaultPartialLineWaiting, "partial_line_waiting")
-	if err != nil {
-		return err
+	if config.ForceCloseFiles {
+		logp.Info("force_close_file is enabled")
+	} else {
+		logp.Info("force_close_file is disabled")
 	}
 
 	return nil
@@ -118,7 +119,7 @@ func getConfigDuration(config string, duration time.Duration, name string) (time
 			return 0, err
 		}
 	}
-	logp.Debug("prospector", "Set %s duration to %s", name, duration)
+	logp.Info("Set %s duration to %s", name, duration)
 
 	return duration, nil
 }

--- a/crawler/prospector_test.go
+++ b/crawler/prospector_test.go
@@ -73,7 +73,6 @@ func TestProspectorInitNotSet(t *testing.T) {
 	assert.Equal(t, config.DefaultBackoff, prospector.ProspectorConfig.Harvester.BackoffDuration)
 	assert.Equal(t, config.DefaultBackoffFactor, prospector.ProspectorConfig.Harvester.BackoffFactor)
 	assert.Equal(t, config.DefaultMaxBackoff, prospector.ProspectorConfig.Harvester.MaxBackoffDuration)
-	assert.Equal(t, config.DefaultPartialLineWaiting, prospector.ProspectorConfig.Harvester.PartialLineWaitingDuration)
 	assert.Equal(t, config.DefaultForceCloseFiles, prospector.ProspectorConfig.Harvester.ForceCloseFiles)
 }
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -145,11 +145,6 @@ the backoff algorithm is disabled, and the `backoff` value is used for waiting f
 lines. The `backoff` value will be multiplied each time with the `backoff_factor` until
 `max_backoff` is reached. The default is 2.
 
-===== partial_line_waiting
-
-Sometimes Filebeat checks a line before it's completely written. This option specifies
-how long the harvester waits for the system to complete a line before skipping that line. The default is 5s.
-
 ===== force_close_files
 
 By default, Filebeat keeps the files that it’s reading open until the timespan specified by `ignore_older` has elapsed. This behaviour can cause issues when a file is removed. Because the file isn't fully removed until Filebeat closes the file, no new file with the same name can be created during this time.

--- a/etc/beat.yml
+++ b/etc/beat.yml
@@ -82,12 +82,6 @@ filebeat:
       # The backoff value will be multiplied each time with the backoff_factor until max_backoff is reached
       #backoff_factor: 2
 
-      # Defines the time on how long the harvester will wait for a line to be completed.
-      # Sometimes a lines it not completely written when checked by filebeat. Filebeat
-      # will wait for the time defined below so the system can complete the line.
-      # In case the line is not completed in this time, the line will be skipped.
-      #partial_line_waiting: 5s
-
       # This option closes a file, as soon as the file name changes.
       # This config option is recommended on windows only. Filebeat keeps the files it's reading open. This can cause
       # issues when the file is removed, as the file will not be fully removed until also Filebeat closes

--- a/harvester/harvester.go
+++ b/harvester/harvester.go
@@ -1,3 +1,16 @@
+/*
+  The harvester package harvest different inputs for new information. Currently
+  two harvester types exist:
+
+   * log
+   * stdin
+
+  The log harvester reads a file line by line. In case the end of a file is found
+  with an incomplete line, the line pointer stays at the beginning of the incomplete
+  line. As soon as the line is completed, it is read and returned.
+
+  The stdin harvesters reads data from stdin.
+*/
 package harvester
 
 import (

--- a/harvester/log_test.go
+++ b/harvester/log_test.go
@@ -59,27 +59,24 @@ func TestReadLine(t *testing.T) {
 	reader, _ := newLineReader(timedIn, codec, 100)
 
 	// Read third line
-	text, bytesread, isPartial, err := readLine(reader, &timedIn.lastReadTime, 0)
+	text, bytesread, err := readLine(reader, &timedIn.lastReadTime)
 
+	assert.Nil(t, err)
 	assert.Equal(t, text, firstLineString[0:len(firstLineString)-1])
 	assert.Equal(t, bytesread, len(firstLineString))
-	assert.Nil(t, err)
-	assert.False(t, isPartial)
 
 	// read second line
-	text, bytesread, isPartial, err = readLine(reader, &timedIn.lastReadTime, 0)
+	text, bytesread, err = readLine(reader, &timedIn.lastReadTime)
 
 	assert.Equal(t, text, secondLineString[0:len(secondLineString)-1])
 	assert.Equal(t, bytesread, len(secondLineString))
 	assert.Nil(t, err)
-	assert.False(t, isPartial)
 
 	// Read third line, which doesn't exist
-	text, bytesread, isPartial, err = readLine(reader, &timedIn.lastReadTime, 0)
+	text, bytesread, err = readLine(reader, &timedIn.lastReadTime)
 	assert.Equal(t, "", text)
 	assert.Equal(t, bytesread, 0)
 	assert.Equal(t, err, io.EOF)
-	assert.False(t, isPartial)
 }
 
 func TestIsLine(t *testing.T) {

--- a/harvester/reader.go
+++ b/harvester/reader.go
@@ -117,6 +117,7 @@ func (l *lineReader) next() ([]byte, int, error) {
 	bytes, err := l.outBuffer.Collect(l.outBuffer.Len())
 	l.outBuffer.Reset()
 	if err != nil {
+		// This should never happen as otherwise we have a broken state
 		panic(err)
 	}
 
@@ -205,34 +206,4 @@ func (l *lineReader) decode(end int) (int, error) {
 
 	l.byteCount += start
 	return start, err
-}
-
-// partial returns current state of decoded input bytes and amount of bytes
-// processed so far. If decoder has detected an error in input stream, the error
-// will be returned.
-func (l *lineReader) partial() ([]byte, int, error) {
-	// decode all input buffer
-	sz, err := l.decode(l.inBuffer.Len())
-	l.inBuffer.Advance(sz)
-	l.inBuffer.Reset()
-
-	l.inOffset -= sz
-	if l.inOffset < 0 {
-		l.inOffset = 0
-	}
-
-	// return current state of outBuffer, but do not consume any content yet
-	bytes := l.outBuffer.Bytes()
-	sz = l.byteCount
-	return bytes, sz, err
-}
-
-// dropPartial drops current output buffer of decoded characters returning total number
-// of input bytes consumed
-func (l *lineReader) dropPartial() int {
-	l.outBuffer.Advance(l.outBuffer.Len())
-	l.outBuffer.Reset()
-	sz := l.byteCount
-	l.byteCount = 0
-	return sz
 }

--- a/harvester/util.go
+++ b/harvester/util.go
@@ -1,0 +1,61 @@
+package harvester
+
+import (
+	"github.com/elastic/libbeat/logp"
+	"time"
+)
+
+// isLine checks if the given byte array is a line, means has a line ending \n
+func isLine(line []byte) bool {
+	if line == nil || len(line) == 0 {
+		return false
+	}
+
+	if line[len(line)-1] != '\n' {
+		return false
+	}
+	return true
+}
+
+// lineEndingChars returns the number of line ending chars the given by array has
+// In case of Unix/Linux files, it is -1, in case of Windows mostly -2
+func lineEndingChars(line []byte) int {
+	if !isLine(line) {
+		return 0
+	}
+
+	if line[len(line)-1] == '\n' {
+		if len(line) > 1 && line[len(line)-2] == '\r' {
+			return 2
+		}
+
+		return 1
+	}
+	return 0
+}
+
+// readLine reads a full line into buffer and returns it.
+// In case of partial lines, readLine does return and error and en empty string
+// This could potentialy be improved / replaced by https://github.com/elastic/libbeat/tree/master/common/streambuf
+func readLine(
+	reader *lineReader,
+	lastReadTime *time.Time,
+) (string, int, error) {
+	for {
+		line, size, err := reader.next()
+
+		// Full line read to be returned
+		if size != 0 && err == nil {
+			logp.Debug("harvester", "full line read")
+			return readlineString(line, size)
+		} else {
+			return "", 0, err
+		}
+	}
+}
+
+// readlineString removes line ending characters from given by array.
+func readlineString(bytes []byte, size int) (string, int, error) {
+	s := string(bytes)[:len(bytes)-lineEndingChars(bytes)]
+	return s, size, nil
+}


### PR DESCRIPTION
Fixes current partial line implementation which is broken by removing partial_line_waiting completely. See https://github.com/elastic/filebeat/issues/296

